### PR TITLE
fix(database): keep first fetched time for no-pubDate articles

### DIFF
--- a/internal/database/article_db.go
+++ b/internal/database/article_db.go
@@ -67,7 +67,7 @@ func (db *DB) SaveArticles(ctx context.Context, articles []*models.Article) erro
 			image_url = excluded.image_url,
 			audio_url = excluded.audio_url,
 			video_url = excluded.video_url,
-			published_at = excluded.published_at,
+			published_at = CASE WHEN ? THEN excluded.published_at ELSE articles.published_at END,
 			translated_title = excluded.translated_title,
 			is_read = excluded.is_read,
 			is_favorite = excluded.is_favorite,
@@ -92,23 +92,49 @@ func (db *DB) SaveArticles(ctx context.Context, articles []*models.Article) erro
 		// Generate unique_id for deduplication
 		uniqueID := urlutil.GenerateArticleUniqueID(article.Title, article.FeedID, article.PublishedAt, article.HasValidPublishedTime)
 
-		// Preserve user-controlled status fields when refreshing an existing article.
-		// Check if article exists to preserve its status
+		// Fetch the existing row to preserve user-controlled status fields and to
+		// detect whether the article actually changed (for no-pubDate feeds).
 		var existingIsRead, existingIsFavorite, existingIsHidden, existingIsReadLater int
-		err := tx.QueryRowContext(ctx, "SELECT is_read, is_favorite, is_hidden, is_read_later FROM articles WHERE unique_id = ?", uniqueID).Scan(&existingIsRead, &existingIsFavorite, &existingIsHidden, &existingIsReadLater)
+		var existingTitle, existingURL, existingImageURL, existingAudioURL, existingVideoURL, existingOriginalSummary, existingAuthor string
+		err := tx.QueryRowContext(ctx, `
+			SELECT is_read, is_favorite, is_hidden, is_read_later,
+				COALESCE(title, ''), COALESCE(url, ''), COALESCE(image_url, ''),
+				COALESCE(audio_url, ''), COALESCE(video_url, ''),
+				COALESCE(original_summary, ''), COALESCE(author, '')
+			FROM articles WHERE unique_id = ?`, uniqueID).Scan(
+			&existingIsRead, &existingIsFavorite, &existingIsHidden, &existingIsReadLater,
+			&existingTitle, &existingURL, &existingImageURL, &existingAudioURL, &existingVideoURL,
+			&existingOriginalSummary, &existingAuthor)
 		isRead := article.IsRead
 		isFavorite := article.IsFavorite
 		isHidden := article.IsHidden
 		isReadLater := article.IsReadLater
+		// Articles with a real pubDate always update their published_at.
+		updatePublishedAt := article.HasValidPublishedTime
 		if err == nil {
 			// Article exists, preserve its status
 			isRead = existingIsRead == 1
 			isFavorite = existingIsFavorite == 1
 			isHidden = existingIsHidden == 1
 			isReadLater = existingIsReadLater == 1
+			// For articles without a pubDate, only move published_at to the current
+			// time when the article actually changed (e.g. edited content); otherwise
+			// keep the original time so it doesn't jump to the top on every refresh.
+			articleChanged := article.Title != existingTitle ||
+				article.URL != existingURL ||
+				article.ImageURL != existingImageURL ||
+				article.AudioURL != existingAudioURL ||
+				article.VideoURL != existingVideoURL ||
+				article.OriginalSummary != existingOriginalSummary ||
+				article.Author != existingAuthor
+			updatePublishedAt = article.HasValidPublishedTime || articleChanged
 		}
 
-		_, err = stmt.ExecContext(ctx, article.FeedID, article.Title, article.URL, article.ImageURL, article.AudioURL, article.VideoURL, article.PublishedAt, article.TranslatedTitle, isRead, isFavorite, isHidden, isReadLater, article.Summary, article.OriginalSummary, uniqueID, article.Author)
+		updateTime := 0
+		if updatePublishedAt {
+			updateTime = 1
+		}
+		_, err = stmt.ExecContext(ctx, article.FeedID, article.Title, article.URL, article.ImageURL, article.AudioURL, article.VideoURL, article.PublishedAt, article.TranslatedTitle, isRead, isFavorite, isHidden, isReadLater, article.Summary, article.OriginalSummary, uniqueID, article.Author, updateTime)
 		if err != nil {
 			log.Println("Error saving article in batch:", err)
 			// Continue even if one fails

--- a/internal/database/article_db_test.go
+++ b/internal/database/article_db_test.go
@@ -586,3 +586,146 @@ func TestArticleDifferentTitlesNotDeduplicated(t *testing.T) {
 		t.Fatalf("expected 2 articles with different titles, got %d", len(articles))
 	}
 }
+
+// TestSaveArticlesNoPubDateKeepsFirstSeenTime verifies that articles without a
+// valid pubDate keep their originally stored published_at on refresh when the
+// article is unchanged, instead of being bumped to the current time every save.
+func TestSaveArticlesNoPubDateKeepsFirstSeenTime(t *testing.T) {
+	db := setupDBWithFeed(t)
+
+	var feedID int64
+	if err := db.QueryRow(`SELECT id FROM feeds WHERE url = ?`, "https://example.com/feed").Scan(&feedID); err != nil {
+		t.Fatalf("scan feed id: %v", err)
+	}
+
+	firstSeen := time.Now()
+	article := &models.Article{
+		FeedID:                feedID,
+		Title:                 "No pubDate article",
+		URL:                   "https://example.com/no-pubdate",
+		PublishedAt:           firstSeen,
+		HasValidPublishedTime: false, // feed item had no pubDate
+	}
+
+	// First save: article is inserted with the first-seen time
+	if err := db.SaveArticles(context.Background(), []*models.Article{article}); err != nil {
+		t.Fatalf("initial SaveArticles error: %v", err)
+	}
+
+	// Simulate the next feed refresh: processArticles stamps a NEW time.Now()
+	// but the article content is unchanged.
+	later := firstSeen.Add(2 * time.Hour)
+	article.PublishedAt = later
+	if err := db.SaveArticles(context.Background(), []*models.Article{article}); err != nil {
+		t.Fatalf("refresh SaveArticles error: %v", err)
+	}
+
+	// Only one article must exist (dedup by title+feedID, no date part)
+	articles, err := db.GetArticles("all", feedID, "", false, 10, 0)
+	if err != nil {
+		t.Fatalf("GetArticles error: %v", err)
+	}
+	if len(articles) != 1 {
+		t.Fatalf("expected 1 article, got %d", len(articles))
+	}
+
+	stored := articles[0].PublishedAt
+	// Must stay at the first-seen time, NOT be bumped to the refresh time
+	if diff := stored.Sub(firstSeen); diff < 0 || diff > time.Minute {
+		t.Fatalf("published_at bumped to refresh time: got %v, want ≈ %v (diff %v)", stored, firstSeen, diff)
+	}
+}
+
+// TestSaveArticlesNoPubDateBumpsOnContentChange verifies that an article without
+// a valid pubDate DOES move to the new time when its content actually changed
+// (e.g. the source entry was edited).
+func TestSaveArticlesNoPubDateBumpsOnContentChange(t *testing.T) {
+	db := setupDBWithFeed(t)
+
+	var feedID int64
+	if err := db.QueryRow(`SELECT id FROM feeds WHERE url = ?`, "https://example.com/feed").Scan(&feedID); err != nil {
+		t.Fatalf("scan feed id: %v", err)
+	}
+
+	firstSeen := time.Now()
+	article := &models.Article{
+		FeedID:                feedID,
+		Title:                 "Edited no-pubDate article",
+		URL:                   "https://example.com/edited/1",
+		PublishedAt:           firstSeen,
+		OriginalSummary:       "old summary",
+		HasValidPublishedTime: false,
+	}
+
+	if err := db.SaveArticles(context.Background(), []*models.Article{article}); err != nil {
+		t.Fatalf("initial SaveArticles error: %v", err)
+	}
+
+	// Next refresh: content changed (summary updated) and processArticles stamped
+	// a new time — published_at should move to the new time.
+	editedAt := firstSeen.Add(2 * time.Hour)
+	article.PublishedAt = editedAt
+	article.OriginalSummary = "updated summary"
+	if err := db.SaveArticles(context.Background(), []*models.Article{article}); err != nil {
+		t.Fatalf("refresh SaveArticles error: %v", err)
+	}
+
+	articles, err := db.GetArticles("all", feedID, "", false, 10, 0)
+	if err != nil {
+		t.Fatalf("GetArticles error: %v", err)
+	}
+	if len(articles) != 1 {
+		t.Fatalf("expected 1 article, got %d", len(articles))
+	}
+
+	stored := articles[0].PublishedAt
+	if diff := stored.Sub(editedAt); diff < 0 || diff > time.Minute {
+		t.Fatalf("changed article time not bumped: got %v, want ≈ %v (diff %v)", stored, editedAt, diff)
+	}
+}
+
+// TestSaveArticlesValidPubDateStillUpdatesTime guards the CASE expression:
+// articles WITH a valid pubDate must still get their real published time on refresh.
+func TestSaveArticlesValidPubDateStillUpdatesTime(t *testing.T) {
+	db := setupDBWithFeed(t)
+
+	var feedID int64
+	if err := db.QueryRow(`SELECT id FROM feeds WHERE url = ?`, "https://example.com/feed").Scan(&feedID); err != nil {
+		t.Fatalf("scan feed id: %v", err)
+	}
+
+	// Same calendar date so the unique_id (title+feedID+date) matches and the
+	// second save hits the ON CONFLICT update path.
+	t1 := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 7, 13, 20, 0, 0, 0, time.UTC)
+	article := &models.Article{
+		FeedID:                feedID,
+		Title:                 "With pubDate article",
+		URL:                   "https://example.com/with-pubdate",
+		PublishedAt:           t1,
+		HasValidPublishedTime: true,
+	}
+
+	if err := db.SaveArticles(context.Background(), []*models.Article{article}); err != nil {
+		t.Fatalf("initial SaveArticles error: %v", err)
+	}
+
+	// Refresh with a new (valid) published time on the same day
+	article.PublishedAt = t2
+	if err := db.SaveArticles(context.Background(), []*models.Article{article}); err != nil {
+		t.Fatalf("refresh SaveArticles error: %v", err)
+	}
+
+	articles, err := db.GetArticles("all", feedID, "", false, 10, 0)
+	if err != nil {
+		t.Fatalf("GetArticles error: %v", err)
+	}
+	if len(articles) != 1 {
+		t.Fatalf("expected 1 article, got %d", len(articles))
+	}
+
+	stored := articles[0].PublishedAt
+	if diff := stored.Sub(t2); diff < 0 || diff > time.Minute {
+		t.Fatalf("valid pubDate not honored on refresh: got %v, want %v (diff %v)", stored, t2, diff)
+	}
+}

--- a/internal/feed/article_processor.go
+++ b/internal/feed/article_processor.go
@@ -51,7 +51,12 @@ func (f *Fetcher) processArticles(feed models.Feed, items []*gofeed.Item) []*Art
 			published = *item.PublishedParsed
 			hasValidPublishedTime = true
 		} else {
-			published = time.Now() // Still set for database storage
+			// No publish date in the feed. Use the current time as a fallback so the
+			// DB always has a value. The upsert in SaveArticles only writes this to
+			// published_at when the article actually changed; for unchanged articles
+			// it keeps the originally stored time, so no-pubDate items don't get
+			// bumped to "now" on every refresh and stay ordered by first appearance.
+			published = time.Now()
 			hasValidPublishedTime = false
 		}
 


### PR DESCRIPTION
# fix(feed): 修复无 pubDate 文章发布时间被不断刷新到当前时间的问题

## 摘要

来自不提供 `pubDate` 的 feed 的文章，其 `published_at` 会在**每次刷新时**被重置为当前时间。结果是这些文章永远显示为"刚刚发布"，被钉在文章列表最顶部，而且永远不会被基于时间的清理逻辑回收。

本次改动修改了 `SaveArticles` 的 upsert 逻辑：无有效 pubDate 的文章只在**内容确实变更**时才更新时间；未变更的文章保留原始存储时间。有真实 pubDate 的文章完全不受影响。

## 问题与根因

一次 feed 刷新的数据流如下：

```
RSS XML → gofeed 解析 → processArticles (models.Article) → SaveArticles (SQLite upsert)
```

1. **`internal/feed/article_processor.go`** — 当条目没有可解析的 `pubDate` 时，`processArticles` 会用 `time.Now()` 兜底，并标记 `HasValidPublishedTime = false`。这个兜底是必要的（DB 插入需要有值）。
2. **`internal/database/article_db.go`** — upsert（`ON CONFLICT(unique_id) DO UPDATE`）此前无条件执行 `published_at = excluded.published_at`。对无 pubDate 的文章来说，每次刷新传入的都是新的 `time.Now()`，导致存储时间被不断往前顶。
3. 所有文章查询都按 `ORDER BY published_at DESC` 排序，所以这些文章永远浮在最上面。

注：去重逻辑不受影响——无 pubDate 文章的 `unique_id` 只由 `title + feed_id` 生成（不含日期），保留原始时间不会产生重复数据。

## 解决方案

`SaveArticles` 的 upsert 现在逐行决定是否更新 `published_at`：

```sql
published_at = CASE WHEN ? THEN excluded.published_at ELSE articles.published_at END
```

绑定参数为 `HasValidPublishedTime || articleChanged`，其中：

- **有有效 pubDate** → 始终使用 feed 提供的时间（`excluded.published_at`），行为不变。
- **无 pubDate + 内容未变** → 保留已存储的时间（`articles.published_at`），不再被顶到 now。
- **无 pubDate + 内容变更**（标题 / URL / 图片 / 音频 / 视频 / 原始摘要 / 作者任一不同）→ 更新时间到 now，将"被编辑过的条目"视为更新。

变更检测复用了 upsert 中原本就要执行的"读取已有行以保留已读/收藏状态"的查询，额外用 `COALESCE` 取出内容字段做对比，**没有新增任何数据库查询**。

`translated_title` 和 AI 生成的 `summary` 刻意不参与变更检测（它们由前端按需生成，不应算作文章编辑）。

## 改动文件

| 文件                                   | 改动                                                            |
| -------------------------------------- | --------------------------------------------------------------- |
| `internal/database/article_db.go`      | 批量 upsert 中 `published_at` 的条件更新 + 基于已有行的变更检测 |
| `internal/database/article_db_test.go` | 新增 3 个测试，覆盖全部三条路径                                 |
| `internal/feed/article_processor.go`   | 仅更新注释——`time.Now()` 兜底逻辑本身不变                       |

## 测试

新增测试（全部通过）：

- `TestSaveArticlesNoPubDateKeepsFirstSeenTime` — 无 pubDate、内容未变、第二次刷新带新时间 → 保持原始时间。
- `TestSaveArticlesNoPubDateBumpsOnContentChange` — 无 pubDate、内容被编辑 → 更新为新时间。
- `TestSaveArticlesValidPubDateStillUpdatesTime` — 有 pubDate、正常刷新 → 使用 feed 时间（对 CASE 表达式的回归保护）。

完整验证：

```
go test ./internal/database/  → ok（3.4s，全套）
go test ./internal/feed/      → ok（11.1s，全套）
go vet  ./internal/...        → 无告警
gofmt  改动文件               → 干净（按 LF 规范化检查）
```

## 对存量数据的影响

- 无需改表结构 / 无需迁移。
- 已存在的无 pubDate 文章：下次刷新时，未变更的文章会冻结在当前存储时间（不再持续被顶到 now），随真实新文章积累自然沉底。
- 已读 / 收藏 / 隐藏 / 稍后读状态照旧保留。
- 前端零改动（`published_at` 始终是真实时间戳）。

## Author
**deepseek v4 flash**
