### PR TITLE
fix(ui): allow switching away from card layout

### DIFF
--- a/frontend/cypress/e2e/settings-persistence.cy.ts
+++ b/frontend/cypress/e2e/settings-persistence.cy.ts
@@ -221,4 +221,111 @@ describe('Settings Persistence', () => {
     cy.contains(/general|常规/i).click({ force: true });
     cy.contains(/dark|深色/i).should('exist');
   });
+
+  it('should switch away from card layout without per-article settings requests', () => {
+    let layoutMode = 'card';
+    let settingsGetCount = 0;
+    let settingsRequestsBeforeSwitch = 0;
+
+    const settingsResponse = () => ({
+      language: 'en-US',
+      layout_mode: layoutMode,
+      update_check_enabled: 'false',
+      update_interval: '10',
+      last_global_refresh: new Date().toISOString(),
+    });
+
+    const articles = Array.from({ length: 24 }, (_, index) => ({
+      id: index + 1,
+      feed_id: 1,
+      feed_title: 'Test Feed',
+      title: `Test Article ${index + 1}`,
+      url: `https://example.com/articles/${index + 1}`,
+      published_at: '2026-08-13T00:00:00Z',
+      image_url: '',
+      translated_title: '',
+      is_read: false,
+      is_favorite: false,
+      is_hidden: false,
+      is_read_later: false,
+    }));
+
+    // Reload with deterministic API state so the regression does not depend on local data.
+    cy.intercept('/api/**', { statusCode: 200, body: {} });
+    cy.intercept('GET', '/api/feeds', { statusCode: 200, body: [] }).as('layoutFeeds');
+    cy.intercept('GET', '/api/tags', { statusCode: 200, body: [] });
+    cy.intercept('GET', '/api/saved-filters', { statusCode: 200, body: [] });
+    cy.intercept(
+      { method: 'GET', pathname: '/api/articles' },
+      {
+        statusCode: 200,
+        body: articles,
+      }
+    ).as('layoutArticles');
+    cy.intercept('GET', '/api/articles/unread-counts', {
+      statusCode: 200,
+      body: { total: 0, feeds: {}, categories: {} },
+    });
+    cy.intercept('GET', '/api/articles/filter-counts', { statusCode: 200, body: {} });
+    cy.intercept('GET', '/api/progress', { statusCode: 200, body: { is_running: false } });
+    cy.intercept('GET', '/api/settings', (req) => {
+      settingsGetCount += 1;
+      req.reply({ statusCode: 200, body: settingsResponse() });
+    }).as('layoutSettings');
+    cy.intercept('POST', '/api/settings', (req) => {
+      layoutMode = req.body.layout_mode;
+      req.reply({ statusCode: 200, body: { success: true } });
+    }).as('saveLayoutSettings');
+
+    const layoutSelector = () =>
+      cy.contains('.setting-item', 'Article List Layout').find('button.select-trigger');
+
+    const selectLayout = (label: string) => {
+      layoutSelector().click();
+      cy.contains('.select-option', label).click({ force: true });
+    };
+
+    cy.reload();
+    cy.wait('@layoutFeeds');
+    cy.wait('@layoutArticles');
+
+    cy.get('button[title="Settings"]').click();
+    cy.contains('button', /^Reading$/).click();
+    layoutSelector().should('contain.text', 'Card');
+    cy.wait(150);
+
+    cy.then(() => {
+      settingsRequestsBeforeSwitch = settingsGetCount;
+    });
+
+    selectLayout('Normal');
+    cy.wait('@saveLayoutSettings').its('request.body.layout_mode').should('eq', 'normal');
+    layoutSelector().should('contain.text', 'Normal');
+    cy.then(() => {
+      expect(settingsGetCount - settingsRequestsBeforeSwitch).to.be.at.most(5);
+    });
+
+    selectLayout('Compact');
+    cy.wait('@saveLayoutSettings').its('request.body.layout_mode').should('eq', 'compact');
+    layoutSelector().should('contain.text', 'Compact');
+
+    selectLayout('Card');
+    cy.wait('@saveLayoutSettings').its('request.body.layout_mode').should('eq', 'card');
+    layoutSelector().should('contain.text', 'Card');
+
+    selectLayout('Normal');
+    cy.wait('@saveLayoutSettings').its('request.body.layout_mode').should('eq', 'normal');
+    layoutSelector().should('contain.text', 'Normal');
+
+    cy.get('body').type('{esc}');
+    cy.reload();
+    cy.wait('@layoutFeeds');
+    cy.wait('@layoutArticles');
+    cy.get('button[title="Settings"]').click();
+    cy.contains('button', /^Reading$/).click();
+    layoutSelector().should('contain.text', 'Normal');
+    cy.then(() => {
+      expect(layoutMode).to.eq('normal');
+    });
+  });
 });

--- a/frontend/src/components/article/ArticleItem.vue
+++ b/frontend/src/components/article/ArticleItem.vue
@@ -34,38 +34,8 @@ const compactMode = computed(() => {
   return settings.value.layout_mode === 'compact';
 });
 
-// Listen for layout mode changes and initial settings load
-let handleLayoutModeChange: (() => void) | null = null;
-
-// Function to load layout mode settings
-function loadLayoutModeSettings() {
-  fetch('/api/settings')
-    .then((res) => res.json())
-    .then((data) => {
-      settings.value = {
-        ...settings.value,
-        layout_mode: data.layout_mode || 'normal',
-      };
-    })
-    .catch((err) => console.error('Error loading settings in ArticleItem:', err));
-}
-
-onMounted(() => {
-  // Load settings immediately when component mounts
-  loadLayoutModeSettings();
-
-  // Listen for layout mode changes
-  handleLayoutModeChange = () => {
-    loadLayoutModeSettings();
-  };
-
-  window.addEventListener('layout-mode-changed', handleLayoutModeChange);
-});
-
-onUnmounted(() => {
-  if (handleLayoutModeChange) {
-    window.removeEventListener('layout-mode-changed', handleLayoutModeChange);
-  }
+const hoverMarkAsRead = computed(() => {
+  return settings.value.hover_mark_as_read;
 });
 
 // Check if article is from RSSHub feed - O(1) lookup using feedMap
@@ -84,7 +54,6 @@ const formatDateWithI18n = (dateStr: string): string => {
 };
 
 const mediaCacheEnabled = ref(false);
-const hoverMarkAsRead = ref(false);
 let hoverTimeout: ReturnType<typeof setTimeout> | null = null;
 
 const imageUrl = computed(() => {
@@ -230,21 +199,6 @@ async function markAsRead() {
     console.error('Error marking as read on hover:', e);
   }
 }
-
-async function loadSettings() {
-  try {
-    const res = await fetch('/api/settings');
-    const data = await res.json();
-    hoverMarkAsRead.value = data.hover_mark_as_read === 'true';
-  } catch (e) {
-    console.error('Error loading hover mark as read setting:', e);
-  }
-}
-
-onMounted(async () => {
-  mediaCacheEnabled.value = await isMediaCacheEnabled();
-  await loadSettings();
-});
 
 onUnmounted(() => {
   if (hoverTimeout) {


### PR DESCRIPTION
## Description

Fixes a race that prevented users from switching away from the card article-list layout. Every mounted `ArticleItem` fetched `/api/settings` and wrote the persisted `layout_mode` back into the shared settings state. When switching from card to normal, newly mounted items could read the still-unsaved `card` value during the autosave debounce and immediately revert the UI.

`ArticleItem` now consumes the existing shared reactive `useSettings()` state for both layout and hover-to-mark-as-read behavior. This also removes settings requests that scaled with the number of rendered articles.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI change
- [ ] ♻️ Code refactoring
- [x] ⚡ Performance improvement
- [x] ✅ Test addition/update

## Related Issues

Fixes #987
Refs #988

Issue #988's refresh-interval behavior is intentionally outside this PR's scope.

## Changes Made

- Removed per-item `/api/settings` reads and `layout-mode-changed` listeners from `ArticleItem.vue`.
- Reused the shared reactive settings state for layout and hover-to-mark-as-read behavior.
- Added a regression to the existing `settings-persistence.cy.ts` covering card → normal → compact → card → normal, modal reopen/reload persistence, and settings request count with 24 articles.

## Screenshots

Not applicable; this fixes behavior without changing the visual design.

## Testing

### Test Configuration

- **OS**: Windows 11 (10.0.26200)
- **MrRSS Version**: 1.3.25
- **Go Version**: 1.25.6 (temporary portable toolchain)
- **Node Version**: 24.19.0/24.x temporary runtime
- **Wails CLI**: v3.0.0-alpha2.117 (temporary install)

### Test Steps

1. Target ESLint/Prettier checks passed for the changed source; the Cypress file also passed ESLint with ignored files enabled.
2. `npm run test:unit`: 6 files and 79 tests passed.
3. `npm run build`: passed.
4. Cypress regression: passed in headless Electron with 24 mocked articles. The repository's default TypeScript 7/Webpack E2E preprocessor currently fails before test execution (`fileExists`); for local execution the unchanged spec was temporarily transpiled to JavaScript with the support file disabled.
5. `go test -count=1 -timeout=5m ./...`: passed.
6. `go build -v ./...`: passed.
7. `wails3 build`: passed and produced `build/bin/MrRSS.exe`.
8. Manual isolated server-mode verification with 24 persisted articles passed for card → normal → compact → card → normal, closing/reopening Settings, and a full process restart; the saved layout remained normal after restart.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation (not required; no user-facing documentation changed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (not applicable)

## Additional Notes

No HTTP API, database schema, settings keys, routes, or platform-specific code were changed.

## Breaking Changes

None.
