### PR TITLE
fix(article): prevent content mismatches for entries without links

### DIFF
--- a/internal/handlers/core/core_test.go
+++ b/internal/handlers/core/core_test.go
@@ -4,10 +4,13 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	"MrRSS/internal/database"
 	"MrRSS/internal/feed"
 	"MrRSS/internal/models"
+
+	"github.com/mmcdole/gofeed"
 )
 
 func TestNewHandler_ConstructsHandler(t *testing.T) {
@@ -101,4 +104,101 @@ func proxyURLFromClient(t *testing.T, client *http.Client) string {
 		t.Fatalf("proxy function returned nil")
 	}
 	return proxy.String()
+}
+
+func TestFindMatchingFeedItem(t *testing.T) {
+	t.Parallel()
+
+	publishedAt := time.Date(2026, time.August, 13, 12, 0, 0, 0, time.UTC)
+	oneMinuteLater := publishedAt.Add(time.Minute)
+	h := &Handler{}
+
+	tests := []struct {
+		name      string
+		article   *models.Article
+		items     []*gofeed.Item
+		wantIndex int
+	}{
+		{
+			name: "empty URLs fall back to title and published time",
+			article: &models.Article{
+				Title:       "Target article",
+				URL:         "",
+				PublishedAt: publishedAt,
+			},
+			items: []*gofeed.Item{
+				{Title: "First article", Link: "", PublishedParsed: &publishedAt},
+				{Title: "Target article", Link: "", PublishedParsed: &oneMinuteLater},
+			},
+			wantIndex: 1,
+		},
+		{
+			name: "matching title wins when multiple items share a URL",
+			article: &models.Article{
+				Title:       "Target article",
+				URL:         "https://example.com/shared",
+				PublishedAt: publishedAt,
+			},
+			items: []*gofeed.Item{
+				{Title: "First article", Link: "https://example.com/shared"},
+				{Title: "Target article", Link: "https://example.com/shared"},
+			},
+			wantIndex: 1,
+		},
+		{
+			name: "non-empty URL remains a fallback when the title changes",
+			article: &models.Article{
+				Title:       "Stored title",
+				URL:         "https://example.com/target?utm_source=rss",
+				PublishedAt: publishedAt,
+			},
+			items: []*gofeed.Item{
+				{Title: "First article", Link: "https://example.com/first"},
+				{Title: "Updated source title", Link: "https://example.com/target"},
+			},
+			wantIndex: 1,
+		},
+		{
+			name: "title-only fallback tolerates whitespace differences",
+			article: &models.Article{
+				Title:       "Target article",
+				PublishedAt: publishedAt,
+			},
+			items: []*gofeed.Item{
+				{Title: "First article"},
+				{Title: "  Target   article  "},
+			},
+			wantIndex: 1,
+		},
+		{
+			name: "unmatched article returns nil",
+			article: &models.Article{
+				Title:       "Missing article",
+				PublishedAt: publishedAt,
+			},
+			items: []*gofeed.Item{
+				{Title: "First article"},
+				{Title: "Second article"},
+			},
+			wantIndex: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := h.findMatchingFeedItem(tt.article, tt.items)
+			if tt.wantIndex == -1 {
+				if got != nil {
+					t.Fatalf("findMatchingFeedItem() = %q, want nil", got.Title)
+				}
+				return
+			}
+
+			if got != tt.items[tt.wantIndex] {
+				t.Fatalf("findMatchingFeedItem() = %v, want item %d", got, tt.wantIndex)
+			}
+		})
+	}
 }

--- a/internal/handlers/core/handler.go
+++ b/internal/handlers/core/handler.go
@@ -262,23 +262,24 @@ func (h *Handler) globalProxyURL() string {
 
 // findMatchingFeedItem finds the best matching feed item for an article using multiple criteria
 func (h *Handler) findMatchingFeedItem(article *models.Article, items []*gofeed.Item) *gofeed.Item {
-	// First pass: exact URL match
+	// First pass: URL + title match. Empty URLs are not valid identifiers and
+	// must never match each other, otherwise the first item in the feed wins.
 	for _, item := range items {
-		if urlutil.URLsMatch(item.Link, article.URL) {
+		if nonEmptyURLsMatch(item.Link, article.URL) && h.titlesMatch(item.Title, article.Title) {
 			return item
 		}
 	}
 
-	// Second pass: URL + title match (for script-based feeds that might have URL variations)
-	for _, item := range items {
-		if urlutil.URLsMatch(item.Link, article.URL) && h.titlesMatch(item.Title, article.Title) {
-			return item
-		}
-	}
-
-	// Third pass: title + published time match (fallback for when URLs don't match)
+	// Second pass: title + published time match (fallback for missing or changed URLs)
 	for _, item := range items {
 		if h.titlesMatch(item.Title, article.Title) && h.publishedTimesMatch(item.PublishedParsed, &article.PublishedAt) {
+			return item
+		}
+	}
+
+	// Third pass: URL-only match for feeds whose titles change between refreshes
+	for _, item := range items {
+		if nonEmptyURLsMatch(item.Link, article.URL) {
 			return item
 		}
 	}
@@ -291,6 +292,12 @@ func (h *Handler) findMatchingFeedItem(article *models.Article, items []*gofeed.
 	}
 
 	return nil
+}
+
+func nonEmptyURLsMatch(url1, url2 string) bool {
+	url1 = strings.TrimSpace(url1)
+	url2 = strings.TrimSpace(url2)
+	return url1 != "" && url2 != "" && urlutil.URLsMatch(url1, url2)
 }
 
 // titlesMatch checks if two titles match, allowing for minor differences


### PR DESCRIPTION
Closes #999.

## Summary

- prevent empty article URLs from participating in URL equality checks
- prefer URL + title, then title + publication time, then non-empty URL, with title as the final fallback
- add regression coverage in the existing core handler test file for Atom entries without alternate links, shared URLs, normal URL matching, and title/time fallback

## Root cause

For Atom feeds that expose only `rel="self"` entry links, `gofeed.Item.Link` is empty. The previous matcher treated two empty strings as equal URLs, so it selected the first feed item and cached that item's body under the currently selected article ID.

## Scope

This PR only changes the server-side feed-item matcher and its existing test file. It does not change the HTTP API, database schema, settings schema, generated code, frontend, documentation, or release metadata.

## Verification

- `go test -v ./internal/handlers/core -run TestFindMatchingFeedItem`
- `go test -v -timeout=5m ./internal/...`
- `cd frontend && npm run lint`
- frontend Vitest: 6 files / 79 tests passed
- frontend production build passed
- `task darwin:build`
- `git diff --check`
- available pre-commit hooks passed: trailing whitespace, EOF fixer, YAML, large files, gofmt, goimports, and `go mod tidy`

## Upstream script compatibility notes

- The configured ESLint pre-commit hook invokes `powershell.exe`, which is unavailable on macOS; the equivalent configured command, `cd frontend && npm run lint`, passed with Node 24.
- `make check` completed lint, vet, formatting, unit tests, frontend build, and macOS build, then failed at the final `./scripts/check.sh` invocation because the checked-in shell script uses CRLF line endings on macOS. Running it explicitly reproduces the same pre-existing line-ending failure.

## Environment

- macOS 26.0
- Go 1.26.5 (project requirement: Go 1.25+)
- Node.js 24.19.0
- Wails `v3.0.0-alpha2.117`

