### PR TITLE
fix(ui): keep activity bar icons centered in WebKit

### DIFF
--- a/frontend/cypress/e2e/app-smoke.cy.ts
+++ b/frontend/cypress/e2e/app-smoke.cy.ts
@@ -22,19 +22,37 @@ describe('Application Smoke Tests', () => {
     cy.get('[class*="sidebar"]').should('be.visible');
 
     // Check for common sidebar elements
-    cy.contains(/all|全部/i).should('exist');
-    cy.contains(/unread|未读/i).should('exist');
+    cy.get('button[title="All Articles"], button[title="所有文章"]').should('exist');
+    cy.get('button[title="Unread"], button[title="未读"]').should('exist');
+  });
+
+  it('should keep all activity bar icons on the same centre line', () => {
+    cy.viewport(1280, 720);
+
+    cy.get('.smart-activity-bar').then(($bar) => {
+      const bar = $bar[0].getBoundingClientRect();
+      const centreX = bar.left + bar.width / 2;
+
+      cy.wrap($bar)
+        .find('button:visible svg')
+        .each(($icon) => {
+          const icon = $icon[0].getBoundingClientRect();
+          const iconCentreX = icon.left + icon.width / 2;
+
+          expect(Math.abs(iconCentreX - centreX)).to.be.lessThan(0.6);
+        });
+    });
   });
 
   it('should have working navigation', () => {
     // Click on different navigation items
-    cy.contains(/all|全部/i).click({ force: true });
+    cy.get('button[title="All Articles"], button[title="所有文章"]').click({ force: true });
     cy.wait(500);
 
-    cy.contains(/unread|未读/i).click({ force: true });
+    cy.get('button[title="Unread"], button[title="未读"]').click({ force: true });
     cy.wait(500);
 
-    cy.contains(/favorite|收藏/i).click({ force: true });
+    cy.get('button[title="Favorites"], button[title="收藏"]').click({ force: true });
     cy.wait(500);
   });
 
@@ -43,15 +61,19 @@ describe('Application Smoke Tests', () => {
     cy.wait('@getFeeds', { timeout: 10000 });
 
     // Open settings - find the gear icon button
-    cy.get('button').filter('[title="Settings"], [title="设置"]').should('exist').click({ force: true });
+    cy.get('button')
+      .filter('[title="Settings"], [title="设置"]')
+      .should('exist')
+      .click({ force: true });
 
     // Wait for modal to appear
     cy.wait(1000);
 
     // Verify modal content is visible (check for settings text or modal structure)
     cy.get('body').then(($body) => {
-      const hasSettingsModal = $body.find(/settings|设置|general|常规/i).length > 0 ||
-                              $body.find('[class*="modal"]').length > 0;
+      const hasSettingsModal =
+        $body.find(/settings|设置|general|常规/i).length > 0 ||
+        $body.find('[class*="modal"]').length > 0;
       if (hasSettingsModal) {
         cy.log('Settings modal opened successfully');
       } else {
@@ -150,11 +172,14 @@ describe('Application Smoke Tests', () => {
     cy.wait('@getFeeds', { timeout: 10000 });
 
     // Select unread filter
-    cy.contains(/unread|未读/i).click({ force: true });
+    cy.get('button[title="Unread"], button[title="未读"]').click({ force: true });
     cy.wait(500);
 
     // Open settings
-    cy.get('button').filter('[title="Settings"], [title="设置"]').should('exist').click({ force: true });
+    cy.get('button')
+      .filter('[title="Settings"], [title="设置"]')
+      .should('exist')
+      .click({ force: true });
     cy.wait(500);
 
     // Close settings
@@ -162,8 +187,6 @@ describe('Application Smoke Tests', () => {
     cy.wait(500);
 
     // Verify unread filter is still active by checking if the element exists
-    cy.contains(/unread|未读/i)
-      .should('exist')
-      .and('be.visible');
+    cy.get('button[title="Unread"], button[title="未读"]').should('exist').and('be.visible');
   });
 });

--- a/frontend/src/components/sidebar/ActivityBar.vue
+++ b/frontend/src/components/sidebar/ActivityBar.vue
@@ -346,37 +346,13 @@ defineExpose({
 .nav-items-container {
   /* Smooth height transition when items are added/removed */
   transition: height 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-  /* Reserve the scrollbar space on both sides so centered icons stay centered. */
-  scrollbar-gutter: stable both-edges;
-  scrollbar-width: thin;
-  scrollbar-color: transparent transparent;
-}
-
-.nav-items-container:hover,
-.nav-items-container:focus-within {
-  scrollbar-color: var(--border-color) transparent;
+  /* Keep scrolling without reserving a native gutter in WKWebView. */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
 
 .nav-items-container::-webkit-scrollbar {
-  width: 4px;
-}
-
-.nav-items-container::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.nav-items-container::-webkit-scrollbar-thumb {
-  background: transparent;
-  border-radius: 2px;
-}
-
-.nav-items-container:hover::-webkit-scrollbar-thumb,
-.nav-items-container:focus-within::-webkit-scrollbar-thumb {
-  background: var(--border-color);
-}
-
-.nav-items-container::-webkit-scrollbar-thumb:hover {
-  background: var(--text-secondary);
+  display: none;
 }
 
 /* Nav item enter/leave transitions */


### PR DESCRIPTION
## Description

Keep the scrollable activity-bar navigation aligned with the fixed logo and bottom actions in macOS WKWebView. The navigation region remains scrollable, but no longer reserves a native scrollbar gutter that shifts its icons horizontally.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 Style/UI change
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test addition/update

## Related Issues

Fixes #1008

## Changes Made

- Hide the native scrollbar without disabling vertical navigation scrolling.
- Remove `scrollbar-gutter: stable both-edges`, which is handled inconsistently by WKWebView.
- Update the existing smoke suite to use current activity-button selectors and assert icon centre-line geometry.

## Visual Verification

Verified in the Wails macOS build that all visible activity-bar action icons share the 56 px bar centre line. The existing smoke test also asserts the icon geometry.

## Testing

### Test Configuration

- **OS**: macOS 26.6.1 arm64
- **MrRSS Version**: `main` at `334b1971` / v1.3.26
- **Go Version**: 1.26.5
- **Node Version**: 24.19.0

### Test Steps

1. Ran `cd frontend && npm run lint`.
2. Ran `app-smoke.cy.ts`: 11 passed, 0 failed.
3. Verified the Wails macOS window visually with the top, navigation, and bottom icons aligned.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Documentation is not required for this internal layout fix
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing target tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The generic pre-commit hooks passed. The repository ESLint hook hardcodes `powershell.exe`; on macOS the equivalent configured command, `cd frontend && npm run lint`, passed directly.

## Breaking Changes

None.
