### PR TITLE
fix(build): sign macOS bundles before packaging

### DIFF
--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -237,9 +237,13 @@ jobs:
       - name: Create installer (macOS)
         if: matrix.platform == 'darwin'
         run: |
+          codesign --deep --force --verify --verbose \
+            --sign - \
+            --entitlements build/darwin/entitlements.plist \
+            build/bin/MrRSS.app
+          codesign --verify --deep --strict --verbose=2 build/bin/MrRSS.app
           chmod +x build/darwin/create-dmg.sh
           ./build/darwin/create-dmg.sh
-        continue-on-error: true
 
       - name: Package application (Linux - tar.gz fallback)
         if: matrix.platform == 'linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -501,9 +501,13 @@ jobs:
       - name: Create installer (macOS)
         if: steps.check_artifacts.outputs.skip_build == 'false' && matrix.platform == 'darwin'
         run: |
+          codesign --deep --force --verify --verbose \
+            --sign - \
+            --entitlements build/darwin/entitlements.plist \
+            build/bin/MrRSS.app
+          codesign --verify --deep --strict --verbose=2 build/bin/MrRSS.app
           chmod +x build/darwin/create-dmg.sh
           ./build/darwin/create-dmg.sh
-        continue-on-error: true
 
       - name: Create portable package (macOS)
         if: steps.check_artifacts.outputs.skip_build == 'false' && matrix.platform == 'darwin'

--- a/build/darwin/Taskfile.yml
+++ b/build/darwin/Taskfile.yml
@@ -103,9 +103,9 @@ tasks:
         EOF
 
   package:
-    summary: Packages the application into a DMG
+    summary: Signs and packages the application into a DMG
     deps:
-      - task: build
+      - task: sign:dev
     cmds:
       - task: create:dmg
 
@@ -193,7 +193,7 @@ tasks:
         fi
 
         # Verify signature
-        codesign --verify --verbose {{.BIN_DIR}}/{{.APP_NAME}}.app
+        codesign --verify --deep --strict --verbose=2 {{.BIN_DIR}}/{{.APP_NAME}}.app
   build:server:
     summary: Builds the server version using Docker
     deps:

--- a/build/darwin/entitlements.plist
+++ b/build/darwin/entitlements.plist
@@ -2,61 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <!-- ============================================================ -->
-    <!-- App Sandbox Configuration                                   -->
-    <!-- ============================================================ -->
-    <!-- NOTE: For non-Mac App Store distribution, you can disable   -->
-    <!-- the sandbox. If publishing to Mac App Store, enable it      -->
-    <!-- and add more specific entitlements below.                   -->
-    <!-- ============================================================ -->
-
-    <!-- Disable App Sandbox for standalone distribution -->
-    <!-- Remove this comment block if you need sandbox enabled -->
-    <!--
-    <key>com.apple.security.app-sandbox</key>
-    <false/>
-    -->
-
-    <!-- ============================================================ -->
-    <!-- Apple Events - Required for opening URLs in browser        -->
-    <!-- ============================================================ -->
-    <key>com.apple.security.automation.apple-events</key>
-    <true/>
-
-    <!-- ============================================================ -->
-    <!-- Network Access - Required for RSS feed fetching             -->
-    <!-- ============================================================ -->
-    <key>com.apple.security.network.client</key>
-    <true/>
-
-    <key>com.apple.security.network.server</key>
-    <true/>
-
-    <!-- ============================================================ -->
-    <!-- File Access - Required for data storage and imports         -->
-    <!-- ============================================================ -->
-    <!-- Allow read/write access to user-selected files -->
-    <key>com.apple.security.files.user-selected.read-write</key>
-    <true/>
-
-    <!-- Allow read/write access to Downloads folder -->
-    <key>com.apple.security.files.downloads.read-write</key>
-    <true/>
-
-    <!-- Allow read/write access to specific app directories -->
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <false/>
-
-    <!-- ============================================================ -->
-    <!-- Optional: Hardware and Media Access                         -->
-    <!-- ============================================================ -->
-    <!-- Uncomment if needed for future features -->
-    <!--
-    <key>com.apple.security.device.camera</key>
-    <false/>
-
-    <key>com.apple.security.device.microphone</key>
-    <false/>
-    -->
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<false/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

Sign and strictly verify the completed macOS app bundle before creating a DMG. This prevents release artifacts whose executable has a linker signature but whose `Info.plist` and resources are not sealed as an app bundle.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI change
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [x] ✅ Test addition/update

## Related Issues

Fixes #1009

## Changes Made

- Make local `darwin:package` depend on the existing ad-hoc signing task.
- Sign and strictly verify `MrRSS.app` in both macOS release workflows before DMG creation.
- Normalize the entitlement plist so current `codesign`/AMFI can parse it reliably.
- Stop ignoring macOS installer creation failures.

## Screenshots

Not applicable; verification is performed with `codesign` and `lipo`.

## Testing

### Test Configuration

- **OS**: macOS 26.6.1 arm64
- **MrRSS Version**: `main` at `334b1971` / v1.3.26
- **Go Version**: 1.26.5
- **Node Version**: 24.19.0
- **Wails Version**: v3.0.0-alpha2.117

### Test Steps

1. Ran `task darwin:package ARCH=universal`.
2. Mounted `MrRSS-1.3.26-darwin-universal.dmg` read-only.
3. Verified `x86_64 arm64` with `lipo -info`.
4. Ran `codesign --verify --deep --strict --verbose=2` successfully against the app inside the DMG.
5. Confirmed `Identifier=com.mrrss.app`, sealed resources v2, and 16 bound `Info.plist` entries.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Documentation is not required for this packaging correction
- [x] My changes generate no new warnings beyond the existing local macOS SDK deployment-target linker warnings
- [x] I have added strict verification to both affected CI workflows
- [x] New and existing target checks pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

All generic pre-commit hooks passed. The produced signature is ad-hoc, matching the repository's existing `sign:dev` behaviour; this change does not add Developer ID notarization.

## Breaking Changes

None.
