### PR TITLE
fix(database): preserve protected articles during manual cleanup

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -798,7 +798,7 @@ const en: TranslationMessages = {
       clean: 'Clean',
       cleanDatabase: 'Clean Database',
       cleanDatabaseMessage:
-        'This will delete all articles except read and favorited ones. Continue?',
+        'This will delete unread articles that are neither favorited nor saved for later. Read, favorited, and read-later articles will be preserved. Continue?',
       cleanDatabaseTitle: 'Clean Database',
       cleaning: 'Cleaning...',
       cleanupArticleContentCache: 'Clean Now',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -784,7 +784,8 @@ const zh: TranslationMessages = {
       autoCleanupDesc: '自动删除旧文章以节省空间',
       clean: '清理',
       cleanDatabase: '清理数据库',
-      cleanDatabaseMessage: '这将删除所有文章，除了已读和收藏的文章。继续吗？',
+      cleanDatabaseMessage:
+        '这将删除未读、未收藏且未加入稍后阅读的文章。已读、收藏和稍后阅读的文章会保留。继续吗？',
       cleanDatabaseTitle: '清理数据库',
       cleaning: '清理中...',
       cleanupArticleContentCache: '立即清理',

--- a/internal/database/cleanup_db.go
+++ b/internal/database/cleanup_db.go
@@ -116,10 +116,6 @@ func (db *DB) CleanupUnimportantArticles() (int64, error) {
 
 	count, _ := result.RowsAffected()
 
-	// Also cleanup related caches (remove entries older than 7 days)
-	_, _ = db.CleanupTranslationCache(7)
-	_, _ = db.CleanupOldArticleContents(7)
-
 	// Reclaim freelist pages
 	if count > 0 {
 		_, _ = db.IncrementalVacuum()

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -323,9 +324,7 @@ func TestCleanupOldArticles(t *testing.T) {
 }
 
 func TestCleanupUnimportantArticles(t *testing.T) {
-	// Create temporary database
-	dbFile := "test_cleanup_unimportant.db"
-	defer os.Remove(dbFile)
+	dbFile := filepath.Join(t.TempDir(), "test_cleanup_unimportant.db")
 
 	db, err := NewDB(dbFile)
 	if err != nil {
@@ -357,7 +356,8 @@ func TestCleanupUnimportantArticles(t *testing.T) {
 		{FeedID: feedID, Title: "Unread Unfav", URL: "https://example.com/1", PublishedAt: time.Now(), IsRead: false, IsFavorite: false},
 		{FeedID: feedID, Title: "Read Unfav", URL: "https://example.com/2", PublishedAt: time.Now(), IsRead: true, IsFavorite: false},
 		{FeedID: feedID, Title: "Unread Fav", URL: "https://example.com/3", PublishedAt: time.Now(), IsRead: false, IsFavorite: true},
-		{FeedID: feedID, Title: "Read Fav", URL: "https://example.com/4", PublishedAt: time.Now(), IsRead: true, IsFavorite: true},
+		{FeedID: feedID, Title: "Unread Read Later", URL: "https://example.com/4", PublishedAt: time.Now(), IsReadLater: true},
+		{FeedID: feedID, Title: "Read Fav", URL: "https://example.com/5", PublishedAt: time.Now(), IsRead: true, IsFavorite: true},
 	}
 
 	for _, article := range articles {
@@ -365,6 +365,28 @@ func TestCleanupUnimportantArticles(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to save article: %v", err)
 		}
+	}
+
+	savedArticles, err := db.GetArticles("", feedID, "", false, 100, 0)
+	if err != nil {
+		t.Fatalf("Failed to load saved articles: %v", err)
+	}
+	articleIDs := make(map[string]int64, len(savedArticles))
+	for _, article := range savedArticles {
+		articleIDs[article.Title] = article.ID
+		if err := db.SetArticleContent(article.ID, "cached content for "+article.Title); err != nil {
+			t.Fatalf("Failed to cache content for %q: %v", article.Title, err)
+		}
+	}
+	if _, err := db.Exec(`UPDATE article_contents SET fetched_at = datetime('now', '-8 days')`); err != nil {
+		t.Fatalf("Failed to age article content cache: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO translation_cache (
+			source_text_hash, source_text, target_lang, translated_text, provider, created_at
+		) VALUES ('old-hash', 'source', 'en', 'translated', 'test', datetime('now', '-8 days'))
+	`); err != nil {
+		t.Fatalf("Failed to insert translation cache: %v", err)
 	}
 
 	// Run cleanup
@@ -380,8 +402,8 @@ func TestCleanupUnimportantArticles(t *testing.T) {
 
 	// Verify remaining articles
 	remainingArticles, _ := db.GetArticles("", feedID, "", false, 100, 0)
-	if len(remainingArticles) != 3 {
-		t.Errorf("Expected 3 articles after cleanup, got %d", len(remainingArticles))
+	if len(remainingArticles) != 4 {
+		t.Errorf("Expected 4 articles after cleanup, got %d", len(remainingArticles))
 	}
 
 	// Verify the right articles remain
@@ -390,10 +412,36 @@ func TestCleanupUnimportantArticles(t *testing.T) {
 		titles[a.Title] = true
 	}
 
-	expectedTitles := []string{"Read Unfav", "Unread Fav", "Read Fav"}
+	expectedTitles := []string{"Read Unfav", "Unread Fav", "Unread Read Later", "Read Fav"}
 	for _, expected := range expectedTitles {
 		if !titles[expected] {
 			t.Errorf("Expected article '%s' to remain after cleanup", expected)
 		}
+		content, found, err := db.GetArticleContent(articleIDs[expected])
+		if err != nil || !found || content == "" {
+			t.Errorf("Expected cached content for %q to remain, found=%v, err=%v", expected, found, err)
+		}
+	}
+
+	if _, found, err := db.GetArticleContent(articleIDs["Unread Unfav"]); err != nil {
+		t.Fatalf("Failed to check deleted article content: %v", err)
+	} else if found {
+		t.Error("Expected deleted article content to be removed by cascade")
+	}
+
+	var translationCacheCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM translation_cache WHERE source_text_hash = 'old-hash'`).Scan(&translationCacheCount); err != nil {
+		t.Fatalf("Failed to count translation cache: %v", err)
+	}
+	if translationCacheCount != 1 {
+		t.Fatalf("Expected unrelated translation cache to remain, got %d", translationCacheCount)
+	}
+
+	secondCount, err := db.CleanupUnimportantArticles()
+	if err != nil {
+		t.Fatalf("Second cleanup failed: %v", err)
+	}
+	if secondCount != 0 {
+		t.Fatalf("Expected idempotent cleanup to delete 0 articles, deleted %d", secondCount)
 	}
 }

--- a/internal/handlers/article/article_bulk.go
+++ b/internal/handlers/article/article_bulk.go
@@ -225,10 +225,10 @@ func HandleRefresh(h *core.Handler, w http.ResponseWriter, r *http.Request) {
 	response.JSON(w, map[string]string{"status": "refreshing"})
 }
 
-// HandleCleanupArticles triggers manual cleanup of articles.
-// This clears ALL articles and article contents, but keeps feeds and settings.
-// @Summary      Cleanup all articles
-// @Description  Delete all articles and article contents (keeps feeds and settings)
+// HandleCleanupArticles triggers manual cleanup of unimportant articles.
+// It preserves read, favorited, and read-later articles and their cached content.
+// @Summary      Cleanup unimportant articles
+// @Description  Delete unread articles that are neither favorited nor saved for later
 // @Tags         articles
 // @Accept       json
 // @Produce      json
@@ -241,29 +241,19 @@ func HandleCleanupArticles(h *core.Handler, w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Manual cleanup: clear ALL articles and article contents, but keep feeds
-	// Step 1: Delete all article contents
-	contentCount, err := h.DB.CleanupAllArticleContents()
+	articleCount, err := h.DB.CleanupUnimportantArticles()
 	if err != nil {
-		log.Printf("Error cleaning up article contents: %v", err)
+		log.Printf("Error cleaning up unimportant articles: %v", err)
 		response.Error(w, err, http.StatusInternalServerError)
 		return
 	}
 
-	// Step 2: Delete all articles (but keep feeds and settings)
-	articleCount, err := h.DB.DeleteAllArticles()
-	if err != nil {
-		log.Printf("Error deleting all articles: %v", err)
-		response.Error(w, err, http.StatusInternalServerError)
-		return
-	}
-
-	log.Printf("Manual cleanup: cleared %d article contents and %d articles", contentCount, articleCount)
+	log.Printf("Manual cleanup: deleted %d unimportant articles", articleCount)
 	response.JSON(w, map[string]interface{}{
-		"deleted":  contentCount + articleCount,
+		"deleted":  articleCount,
 		"articles": articleCount,
-		"contents": contentCount,
-		"type":     "all",
+		"contents": int64(0),
+		"type":     "unimportant",
 	})
 }
 

--- a/internal/handlers/article/article_handlers_test.go
+++ b/internal/handlers/article/article_handlers_test.go
@@ -247,6 +247,74 @@ func TestHandleReloadArticleContentClearsOnlyArticleContent(t *testing.T) {
 	}
 }
 
+func TestHandleCleanupArticlesPreservesProtectedArticles(t *testing.T) {
+	h := setupHandler(t)
+	feedID, err := h.DB.AddFeed(&models.Feed{Title: "Cleanup Feed", URL: "http://example.com/cleanup"})
+	if err != nil {
+		t.Fatalf("AddFeed: %v", err)
+	}
+
+	articles := []*models.Article{
+		{FeedID: feedID, Title: "Delete", URL: "http://example.com/delete", PublishedAt: time.Now()},
+		{FeedID: feedID, Title: "Read", URL: "http://example.com/read", PublishedAt: time.Now(), IsRead: true},
+		{FeedID: feedID, Title: "Favorite", URL: "http://example.com/favorite", PublishedAt: time.Now(), IsFavorite: true},
+		{FeedID: feedID, Title: "Read Later", URL: "http://example.com/read-later", PublishedAt: time.Now(), IsReadLater: true},
+	}
+	if err := h.DB.SaveArticles(context.Background(), articles); err != nil {
+		t.Fatalf("SaveArticles: %v", err)
+	}
+
+	savedArticles, err := h.DB.GetArticles("", feedID, "", false, 10, 0)
+	if err != nil {
+		t.Fatalf("GetArticles: %v", err)
+	}
+	for _, savedArticle := range savedArticles {
+		if err := h.DB.SetArticleContent(savedArticle.ID, "cached "+savedArticle.Title); err != nil {
+			t.Fatalf("SetArticleContent: %v", err)
+		}
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/articles/cleanup", nil)
+	getRecorder := httptest.NewRecorder()
+	article.HandleCleanupArticles(h, getRecorder, getReq)
+	if getRecorder.Result().StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("expected GET cleanup to return 405, got %d", getRecorder.Result().StatusCode)
+	}
+
+	postReq := httptest.NewRequest(http.MethodPost, "/api/articles/cleanup", nil)
+	postRecorder := httptest.NewRecorder()
+	article.HandleCleanupArticles(h, postRecorder, postReq)
+	if postRecorder.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected cleanup to return 200, got %d: %s", postRecorder.Result().StatusCode, postRecorder.Body.String())
+	}
+
+	var result struct {
+		Deleted  int64  `json:"deleted"`
+		Articles int64  `json:"articles"`
+		Contents int64  `json:"contents"`
+		Type     string `json:"type"`
+	}
+	if err := json.NewDecoder(postRecorder.Result().Body).Decode(&result); err != nil {
+		t.Fatalf("decode cleanup response: %v", err)
+	}
+	if result.Deleted != 1 || result.Articles != 1 || result.Contents != 0 || result.Type != "unimportant" {
+		t.Fatalf("unexpected cleanup response: %+v", result)
+	}
+
+	remaining, err := h.DB.GetArticles("", feedID, "", false, 10, 0)
+	if err != nil {
+		t.Fatalf("GetArticles after cleanup: %v", err)
+	}
+	if len(remaining) != 3 {
+		t.Fatalf("expected 3 protected articles, got %d", len(remaining))
+	}
+	for _, remainingArticle := range remaining {
+		if _, found, err := h.DB.GetArticleContent(remainingArticle.ID); err != nil || !found {
+			t.Fatalf("expected cached content for %q to remain, found=%v, err=%v", remainingArticle.Title, found, err)
+		}
+	}
+}
+
 func TestHandleExportToObsidian(t *testing.T) {
 	h := setupHandler(t)
 


### PR DESCRIPTION
## Summary

- make manual database cleanup delete only articles that are unread, not favorited, and not in Read Later
- preserve cached bodies for protected articles and remove unrelated global cache cleanup side effects
- keep the existing response fields while reporting the actual article count and the `unimportant` cleanup type
- clarify the cleanup confirmation text in English and Chinese

## Root cause

`HandleCleanupArticles` called `CleanupAllArticleContents()` and `DeleteAllArticles()`, even though the confirmation dialog promised to preserve read and favorite articles. `CleanupUnimportantArticles()` already had the correct protection predicate, but also removed unrelated translation and article-body caches older than seven days.

## API compatibility

The endpoint and response field names are unchanged. `deleted` and `articles` now both contain the actual number of deleted articles, `contents` is `0` because no separate global body-cache cleanup runs, and `type` is `unimportant`.

## Validation

- `go test -v ./internal/database -run TestCleanupUnimportantArticles`
- `go test -v ./internal/handlers/article -run TestHandleCleanupArticlesPreservesProtectedArticles`
- `go test -v -timeout=5m ./internal/database ./internal/handlers/article`
- `npm run lint`
- `npm run build`
- all available pre-commit hooks; the macOS-incompatible PowerShell ESLint hook was run directly as `cd frontend && npm run lint`

Fixes #1006
