### PR TITLE
fix(search): explain AI results and open selected articles

### DIFF
--- a/frontend/cypress/e2e/article-operations.cy.ts
+++ b/frontend/cypress/e2e/article-operations.cy.ts
@@ -163,4 +163,150 @@ describe('Article Operations', () => {
       }
     });
   });
+
+  it('should explain AI search results and keep list and card navigation in search context', () => {
+    const settingsState: Record<string, string> = {
+      language: 'en-US',
+      theme: 'light',
+      layout_mode: 'normal',
+      default_view_mode: 'rendered',
+      ai_search_enabled: 'true',
+      translation_mode: 'off',
+      summary_enabled: 'false',
+      full_text_fetch_enabled: 'false',
+      update_check_enabled: 'false',
+    };
+    const feed = {
+      id: 1,
+      title: 'Search Feed',
+      url: 'https://example.com/feed.xml',
+      category: '',
+      article_view_mode: 'global',
+    };
+    const timelineArticle = {
+      id: 1,
+      feed_id: 1,
+      feed_title: feed.title,
+      title: 'Timeline article outside search results',
+      url: 'https://example.com/timeline',
+      published_at: '2026-08-20T00:00:00Z',
+      is_read: false,
+      is_favorite: false,
+      is_hidden: false,
+      is_read_later: false,
+    };
+    const searchArticles = [101, 102, 103].map((id, index) => ({
+      id,
+      feed_id: 1,
+      feed_title: feed.title,
+      title: `Search result ${index + 1}`,
+      url: `https://example.com/search/${id}`,
+      published_at: `2026-08-${23 - index}T00:00:00Z`,
+      is_read: false,
+      is_favorite: false,
+      is_hidden: false,
+      is_read_later: false,
+      relevance_score: 90 - index,
+      matched_terms: ['privacy'],
+      matched_fields: index === 0 ? ['title', 'summary'] : ['content'],
+      excerpt: `This privacy excerpt explains result ${index + 1}`,
+    }));
+
+    cy.intercept('/api/**', { statusCode: 200, body: {} });
+    cy.intercept('GET', '/api/settings', (req) => {
+      req.reply({ statusCode: 200, body: settingsState });
+    });
+    cy.intercept('GET', '/api/feeds', { statusCode: 200, body: [feed] }).as('searchFeeds');
+    cy.intercept('GET', '/api/tags', { statusCode: 200, body: [] });
+    cy.intercept('GET', '/api/saved-filters', { statusCode: 200, body: [] });
+    cy.intercept(
+      { method: 'GET', pathname: '/api/articles' },
+      { statusCode: 200, body: [timelineArticle] }
+    ).as('timelineArticles');
+    cy.intercept('GET', '/api/articles/unread-counts', { statusCode: 200, body: {} });
+    cy.intercept('GET', '/api/articles/filter-counts', { statusCode: 200, body: {} });
+    cy.intercept('GET', '/api/progress', { statusCode: 200, body: { is_running: false } });
+    cy.intercept('POST', '/api/ai/search', (req) => {
+      const noResults = req.body?.query === 'nothing matches';
+      req.reply({
+        statusCode: 200,
+        body: {
+          success: true,
+          articles: noResults ? [] : searchArticles,
+          total_count: noResults ? 0 : searchArticles.length,
+        },
+      });
+    }).as('aiSearch');
+    cy.intercept('GET', '/api/articles/content*', (req) => {
+      req.reply({
+        statusCode: 200,
+        body: { content: `<p>Body for search result ${req.query.id}</p>`, cached: true },
+      });
+    }).as('searchArticleContent');
+    cy.intercept('POST', '/api/articles/read*', { statusCode: 200, body: { success: true } });
+    cy.intercept('POST', '/api/articles/favorite*', {
+      statusCode: 200,
+      body: { success: true },
+    });
+    cy.intercept('POST', '/api/articles/toggle-read-later*', {
+      statusCode: 200,
+      body: { success: true },
+    });
+
+    cy.window().then((win) => win.localStorage.setItem('showOnlyUnread', 'true'));
+    cy.reload();
+    cy.wait('@searchFeeds');
+    cy.wait('@timelineArticles');
+
+    cy.get('input[placeholder="Describe what you want to find..."]').type('privacy');
+    cy.contains('button', /^AI Search$/).click();
+    cy.wait('@aiSearch');
+    cy.contains('Title match').should('be.visible');
+    cy.contains('Summary match').should('be.visible');
+    cy.contains('This privacy excerpt explains result 1').should('be.visible');
+
+    cy.get('[data-article-id="101"]').click();
+    cy.wait('@searchArticleContent');
+    cy.contains('Body for search result 101').should('be.visible');
+
+    // The next result is marked read when opened, but must remain selected and
+    // renderable while the unread-only preference is active.
+    cy.get('button[title="Next Article"]').click();
+    cy.wait('@searchArticleContent');
+    cy.contains('Body for search result 102').should('be.visible');
+    cy.get('[data-article-id="102"]').should('exist');
+
+    // Global shortcuts must use the same ordered search context instead of the
+    // separately paginated timeline.
+    cy.get('body').trigger('keydown', { key: 'j' });
+    cy.wait('@searchArticleContent');
+    cy.contains('Body for search result 103').should('be.visible');
+    cy.get('button[title="Previous Article"]').click();
+    cy.wait('@searchArticleContent');
+    cy.contains('Body for search result 102').should('be.visible');
+
+    cy.contains('button', /^Clear$/).click();
+    cy.get('input[placeholder="Describe what you want to find..."]').type('nothing matches');
+    cy.contains('button', /^AI Search$/).click();
+    cy.wait('@aiSearch');
+    cy.contains('No articles found matching your search').should('be.visible');
+
+    // Card mode uses ArticleDetailModal, which must use the same navigation
+    // context instead of hiding navigation for off-page search results.
+    cy.then(() => {
+      settingsState.layout_mode = 'card';
+    });
+    cy.reload();
+    cy.wait('@searchFeeds');
+    cy.wait('@timelineArticles');
+    cy.get('input[placeholder="Describe what you want to find..."]').type('privacy');
+    cy.contains('button', /^AI Search$/).click();
+    cy.wait('@aiSearch');
+    cy.get('.article-card-item[data-article-id="101"]').click();
+    cy.wait('@searchArticleContent');
+    cy.contains('Body for search result 101').should('be.visible');
+    cy.get('button[title="Next Article"]').should('be.visible').click();
+    cy.wait('@searchArticleContent');
+    cy.contains('Body for search result 102').should('be.visible');
+  });
 });

--- a/frontend/src/components/article/AISearchBar.vue
+++ b/frontend/src/components/article/AISearchBar.vue
@@ -60,6 +60,13 @@ async function performAISearch() {
       author: item.author as string,
       translated_title: item.translated_title as string,
       summary: item.summary as string,
+      original_summary: item.original_summary as string,
+      relevance_score: item.relevance_score as number,
+      matched_terms: Array.isArray(item.matched_terms) ? (item.matched_terms as string[]) : [],
+      matched_fields: Array.isArray(item.matched_fields)
+        ? (item.matched_fields as Article['matched_fields'])
+        : [],
+      excerpt: typeof item.excerpt === 'string' ? item.excerpt : '',
     }));
 
     hasResults.value = true;

--- a/frontend/src/components/article/ArticleDetailModal.vue
+++ b/frontend/src/components/article/ArticleDetailModal.vue
@@ -151,14 +151,17 @@ async function exportToZotero() {
 }
 
 // Navigation
+const navigationArticles = computed(() => store.navigableArticles);
 const currentArticleIndex = computed(() => {
   if (!props.article) return -1;
-  return store.articles.findIndex((a) => a.id === props.article.id);
+  return navigationArticles.value.findIndex((a) => a.id === props.article.id);
 });
 
 const hasPreviousArticle = computed(() => currentArticleIndex.value > 0);
 const hasNextArticle = computed(
-  () => currentArticleIndex.value >= 0 && currentArticleIndex.value < store.articles.length - 1
+  () =>
+    currentArticleIndex.value >= 0 &&
+    currentArticleIndex.value < navigationArticles.value.length - 1
 );
 
 // Load default view mode on mount

--- a/frontend/src/components/article/ArticleList.vue
+++ b/frontend/src/components/article/ArticleList.vue
@@ -94,14 +94,18 @@ const isFilterLoading = computed(() => store.isFilterLoading);
 
 // Computed filtered articles - optimized to avoid excessive recomputation
 const filteredArticles = computed(() => {
-  const usesClientSideUnreadFilter =
-    activeFilters.value.length > 0 || (isAISearchActive.value && aiSearchResults.value.length > 0);
+  const usesClientSideUnreadFilter = activeFilters.value.length > 0 || isAISearchActive.value;
 
   // If AI search is active, use AI search results
-  if (isAISearchActive.value && aiSearchResults.value.length > 0) {
+  if (isAISearchActive.value) {
     let articles = aiSearchResults.value;
     if (store.showOnlyUnread) {
-      articles = articles.filter((article) => !article.is_read);
+      articles = articles.filter(
+        (article) =>
+          !article.is_read ||
+          temporarilyKeepArticles.value.has(article.id) ||
+          article.id === store.currentArticleId
+      );
     }
     return articles;
   }
@@ -129,13 +133,66 @@ const filteredArticles = computed(() => {
 
 // AI Search handlers
 function handleAISearchResults(articles: Article[]) {
+  temporarilyKeepArticles.value.clear();
   aiSearchResults.value = articles;
   isAISearchActive.value = true;
+  store.setArticleNavigationContext(articles);
 }
 
 function handleAISearchClear() {
+  temporarilyKeepArticles.value.clear();
   aiSearchResults.value = [];
   isAISearchActive.value = false;
+  store.setArticleNavigationContext(null);
+  if (
+    store.currentArticleId !== null &&
+    !store.articles.some((article) => article.id === store.currentArticleId)
+  ) {
+    store.currentArticleId = null;
+  }
+}
+
+interface SearchExcerptPart {
+  text: string;
+  matched: boolean;
+}
+
+function searchExcerptParts(article: Article): SearchExcerptPart[] {
+  const excerpt = article.excerpt || '';
+  const terms = (article.matched_terms || [])
+    .map((term) => term.replaceAll('%', ' ').replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length);
+  if (!excerpt || terms.length === 0) return excerpt ? [{ text: excerpt, matched: false }] : [];
+
+  const result: SearchExcerptPart[] = [];
+  const lowerExcerpt = excerpt.toLocaleLowerCase();
+  let position = 0;
+  while (position < excerpt.length) {
+    let nextIndex = -1;
+    let nextTerm = '';
+    for (const term of terms) {
+      const index = lowerExcerpt.indexOf(term.toLocaleLowerCase(), position);
+      if (index >= 0 && (nextIndex < 0 || index < nextIndex)) {
+        nextIndex = index;
+        nextTerm = term;
+      }
+    }
+    if (nextIndex < 0) {
+      result.push({ text: excerpt.slice(position), matched: false });
+      break;
+    }
+    if (nextIndex > position) {
+      result.push({ text: excerpt.slice(position, nextIndex), matched: false });
+    }
+    result.push({ text: excerpt.slice(nextIndex, nextIndex + nextTerm.length), matched: true });
+    position = nextIndex + nextTerm.length;
+  }
+  return result;
+}
+
+function searchFieldLabel(field: 'title' | 'summary' | 'content'): string {
+  return t(`aiSearch.matchFields.${field}`);
 }
 
 const { showArticleContextMenu } = useArticleActions(t, defaultViewMode, async () => {
@@ -308,7 +365,34 @@ watch(
   }
 );
 
+// Keep detail navigation aligned with the currently visible AI result order,
+// including the unread-only preference, without replacing the main timeline.
+watch(
+  () => (isAISearchActive.value ? filteredArticles.value.map((article) => article.id) : []),
+  () => {
+    if (isAISearchActive.value) {
+      store.setArticleNavigationContext([...filteredArticles.value]);
+    }
+  }
+);
+
+// Detail buttons and global shortcuts can move inside the search result set
+// without going through selectArticle(). Keep only the newly selected result
+// visible when the unread-only filter marks it as read.
+watch(
+  () => store.currentArticleId,
+  (articleId) => {
+    if (!isAISearchActive.value) return;
+    if (articleId !== null && aiSearchResults.value.some((article) => article.id === articleId)) {
+      temporarilyKeepArticles.value.add(articleId);
+    }
+  }
+);
+
 onBeforeUnmount(() => {
+  if (isAISearchActive.value) {
+    store.setArticleNavigationContext(null);
+  }
   cleanupTranslation();
   // Clear scroll throttle timer
   if (scrollThrottleTimer) {
@@ -452,7 +536,7 @@ function selectArticle(article: Article): void {
 
   // Normal article selection - show in app
   // If switching from one article to another, remove the previous one from temp list
-  if (store.currentArticleId) {
+  if (store.currentArticleId && !isAISearchActive.value) {
     temporarilyKeepArticles.value.delete(store.currentArticleId);
   }
 
@@ -1021,27 +1105,85 @@ async function markAllVisibleAsRead(): Promise<void> {
       <!-- Article list with content-visibility for performance -->
       <!-- Card mode: grid layout -->
       <div v-if="isCardMode" class="card-grid-container">
-        <ArticleCardItem
+        <div
           v-for="article in visibleArticles"
           :key="article.id"
-          :article="article"
-          :is-active="cardModalArticle?.id === article.id"
-          @click="selectArticle(article)"
-          @contextmenu="(e) => showArticleContextMenu(e, article)"
-        />
+          class="min-w-0 overflow-hidden rounded-lg"
+        >
+          <ArticleCardItem
+            :article="article"
+            :is-active="cardModalArticle?.id === article.id"
+            @click="selectArticle(article)"
+            @contextmenu="(e) => showArticleContextMenu(e, article)"
+          />
+          <div
+            v-if="isAISearchActive && article.excerpt"
+            class="border-t border-border/50 bg-bg-secondary/70 px-3 py-2 text-xs text-text-secondary"
+          >
+            <div class="mb-1 flex flex-wrap items-center gap-1.5">
+              <span class="font-medium text-accent">
+                {{
+                  t('aiSearch.relevanceScore', { score: Math.round(article.relevance_score || 0) })
+                }}
+              </span>
+              <span
+                v-for="field in article.matched_fields || []"
+                :key="field"
+                class="rounded bg-accent/10 px-1.5 py-0.5 text-accent"
+              >
+                {{ searchFieldLabel(field) }}
+              </span>
+            </div>
+            <p class="line-clamp-3 leading-5">
+              <template v-for="(part, index) in searchExcerptParts(article)" :key="index">
+                <mark v-if="part.matched" class="rounded bg-accent/20 px-0.5 text-text-primary">{{
+                  part.text
+                }}</mark>
+                <span v-else>{{ part.text }}</span>
+              </template>
+            </p>
+          </div>
+        </div>
       </div>
       <!-- Normal/Compact mode: list layout -->
       <div v-else class="article-list-container">
-        <ArticleItem
-          v-for="article in visibleArticles"
-          :key="article.id"
-          :article="article"
-          :is-active="store.currentArticleId === article.id"
-          @click="selectArticle(article)"
-          @contextmenu="(e) => showArticleContextMenu(e, article)"
-          @observe-element="observeArticle"
-          @hover-mark-as-read="handleHoverMarkAsRead"
-        />
+        <div v-for="article in visibleArticles" :key="article.id" class="min-w-0">
+          <ArticleItem
+            :article="article"
+            :is-active="store.currentArticleId === article.id"
+            @click="selectArticle(article)"
+            @contextmenu="(e) => showArticleContextMenu(e, article)"
+            @observe-element="observeArticle"
+            @hover-mark-as-read="handleHoverMarkAsRead"
+          />
+          <div
+            v-if="isAISearchActive && article.excerpt"
+            class="border-b border-border bg-bg-secondary/60 px-3 pb-2 pt-1.5 text-xs text-text-secondary"
+          >
+            <div class="mb-1 flex flex-wrap items-center gap-1.5">
+              <span class="font-medium text-accent">
+                {{
+                  t('aiSearch.relevanceScore', { score: Math.round(article.relevance_score || 0) })
+                }}
+              </span>
+              <span
+                v-for="field in article.matched_fields || []"
+                :key="field"
+                class="rounded bg-accent/10 px-1.5 py-0.5 text-accent"
+              >
+                {{ searchFieldLabel(field) }}
+              </span>
+            </div>
+            <p class="line-clamp-2 leading-5">
+              <template v-for="(part, index) in searchExcerptParts(article)" :key="index">
+                <mark v-if="part.matched" class="rounded bg-accent/20 px-0.5 text-text-primary">{{
+                  part.text
+                }}</mark>
+                <span v-else>{{ part.text }}</span>
+              </template>
+            </p>
+          </div>
+        </div>
       </div>
 
       <!-- Bottom: Mark All Visible as Read button (inserted at end of list) -->

--- a/frontend/src/composables/article/useArticleDetail.ts
+++ b/frontend/src/composables/article/useArticleDetail.ts
@@ -24,14 +24,16 @@ export function useArticleDetail() {
   const store = useAppStore();
   const { t, locale } = useI18n();
 
+  const navigationArticles = computed(() => store.navigableArticles);
+
   const article = computed<Article | undefined>(() =>
-    store.articles.find((a) => a.id === store.currentArticleId)
+    navigationArticles.value.find((a) => a.id === store.currentArticleId)
   );
 
   // Get current article index in the filtered list
   const currentArticleIndex = computed(() => {
     if (!store.currentArticleId) return -1;
-    return store.articles.findIndex((a) => a.id === store.currentArticleId);
+    return navigationArticles.value.findIndex((a) => a.id === store.currentArticleId);
   });
 
   // Check if there's a previous article
@@ -39,13 +41,15 @@ export function useArticleDetail() {
 
   // Check if there's a next article
   const hasNextArticle = computed(
-    () => currentArticleIndex.value >= 0 && currentArticleIndex.value < store.articles.length - 1
+    () =>
+      currentArticleIndex.value >= 0 &&
+      currentArticleIndex.value < navigationArticles.value.length - 1
   );
 
   // Navigate to previous article
   function goToPreviousArticle() {
     if (hasPreviousArticle.value) {
-      const prevArticle = store.articles[currentArticleIndex.value - 1];
+      const prevArticle = navigationArticles.value[currentArticleIndex.value - 1];
       store.currentArticleId = prevArticle.id;
       markAsReadIfNeeded(prevArticle);
       scrollArticleIntoView(prevArticle.id);
@@ -55,7 +59,7 @@ export function useArticleDetail() {
   // Navigate to next article
   function goToNextArticle() {
     if (hasNextArticle.value) {
-      const nextArticle = store.articles[currentArticleIndex.value + 1];
+      const nextArticle = navigationArticles.value[currentArticleIndex.value + 1];
       store.currentArticleId = nextArticle.id;
       markAsReadIfNeeded(nextArticle);
       scrollArticleIntoView(nextArticle.id);
@@ -88,7 +92,7 @@ export function useArticleDetail() {
   }
 
   // Expose articles list and index for UI display
-  const articles = computed(() => store.articles);
+  const articles = computed(() => navigationArticles.value);
   const currentArticleIndexForDisplay = computed(() => currentArticleIndex.value + 1);
 
   // Get effective view mode based on feed settings and global settings

--- a/frontend/src/composables/ui/useKeyboardShortcuts.ts
+++ b/frontend/src/composables/ui/useKeyboardShortcuts.ts
@@ -83,7 +83,7 @@ export function useKeyboardShortcuts(callbacks: KeyboardShortcutCallbacks) {
   }
 
   function navigateArticle(direction: number): void {
-    const articles = store.articles;
+    const articles = store.navigableArticles;
     if (!articles || articles.length === 0) return;
 
     const currentIndex = store.currentArticleId
@@ -103,7 +103,7 @@ export function useKeyboardShortcuts(callbacks: KeyboardShortcutCallbacks) {
   }
 
   function selectArticleByIndex(index: number): void {
-    const article = store.articles[index];
+    const article = store.navigableArticles[index];
     if (!article) return;
 
     store.currentArticleId = article.id;
@@ -126,7 +126,7 @@ export function useKeyboardShortcuts(callbacks: KeyboardShortcutCallbacks) {
   }
 
   function toggleCurrentArticleRead(): void {
-    const article = store.articles.find((a) => a.id === store.currentArticleId);
+    const article = store.navigableArticles.find((a) => a.id === store.currentArticleId);
     if (!article) return;
 
     const newState = !article.is_read;
@@ -140,7 +140,7 @@ export function useKeyboardShortcuts(callbacks: KeyboardShortcutCallbacks) {
   }
 
   function toggleCurrentArticleFavorite(): void {
-    const article = store.articles.find((a) => a.id === store.currentArticleId);
+    const article = store.navigableArticles.find((a) => a.id === store.currentArticleId);
     if (!article) return;
 
     const newState = !article.is_favorite;
@@ -152,7 +152,7 @@ export function useKeyboardShortcuts(callbacks: KeyboardShortcutCallbacks) {
   }
 
   function toggleCurrentArticleReadLater(): void {
-    const article = store.articles.find((a) => a.id === store.currentArticleId);
+    const article = store.navigableArticles.find((a) => a.id === store.currentArticleId);
     if (!article) return;
 
     const newState = !article.is_read_later;
@@ -170,7 +170,7 @@ export function useKeyboardShortcuts(callbacks: KeyboardShortcutCallbacks) {
   }
 
   function openCurrentArticleInBrowser(): void {
-    const article = store.articles.find((a) => a.id === store.currentArticleId);
+    const article = store.navigableArticles.find((a) => a.id === store.currentArticleId);
     if (article && article.url) {
       openInBrowser(article.url);
     }
@@ -372,7 +372,7 @@ export function useKeyboardShortcuts(callbacks: KeyboardShortcutCallbacks) {
         navigateArticle(-1);
         break;
       case 'openArticle':
-        if (store.articles.length > 0 && !store.currentArticleId) {
+        if (store.navigableArticles.length > 0 && !store.currentArticleId) {
           selectArticleByIndex(0);
         }
         break;

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -137,6 +137,12 @@ const en: TranslationMessages = {
     foundResults: 'Found {count} articles',
     noResults: 'No articles found matching your search',
     placeholder: 'Describe what you want to find...',
+    relevanceScore: 'Relevance {score}',
+    matchFields: {
+      title: 'Title match',
+      summary: 'Summary match',
+      content: 'Content match',
+    },
     searchFailed: 'AI search failed. Please check your AI settings.',
     showingResults: 'Showing AI search results',
   },

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -132,6 +132,12 @@ const zh: TranslationMessages = {
     foundResults: '找到 {count} 篇文章',
     noResults: '没有找到符合搜索条件的文章',
     placeholder: '描述你想要查找的内容...',
+    relevanceScore: '相关度 {score}',
+    matchFields: {
+      title: '标题命中',
+      summary: '摘要命中',
+      content: '正文命中',
+    },
     searchFailed: 'AI 搜索失败，请检查 AI 设置。',
     showingResults: '正在显示 AI 搜索结果',
   },

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -33,6 +33,7 @@ export interface AppState {
   showOnlyUnread: Ref<boolean>;
   activeFilters: Ref<FilterCondition[]>;
   filteredArticlesFromServer: Ref<Article[]>;
+  articleNavigationContext: Ref<Article[] | null>;
   isFilterLoading: Ref<boolean>;
 }
 
@@ -57,6 +58,7 @@ export interface AppActions {
   startAutoRefresh: (minutes: number) => void;
   toggleShowOnlyUnread: () => void;
   setActiveFilters: (filters: FilterCondition[]) => void;
+  setArticleNavigationContext: (articles: Article[] | null) => void;
 }
 
 export const useAppStore = defineStore('app', () => {
@@ -99,6 +101,13 @@ export const useAppStore = defineStore('app', () => {
   const showOnlyUnread = ref<boolean>(localStorage.getItem('showOnlyUnread') === 'true');
   const activeFilters = ref<FilterCondition[]>([]);
   const filteredArticlesFromServer = ref<Article[]>([]);
+  // A temporary ordered list used by result views (for example AI search).
+  // Keeping this in the store lets ArticleDetail resolve and navigate articles
+  // which are not part of the currently paginated timeline.
+  const articleNavigationContext = ref<Article[] | null>(null);
+  const navigableArticles = computed<Article[]>(
+    () => articleNavigationContext.value ?? articles.value
+  );
   const isFilterLoading = ref(false);
 
   // Article view mode preferences (persisted across component mounts)
@@ -782,6 +791,10 @@ export const useAppStore = defineStore('app', () => {
     filteredArticlesFromServer.value = articles;
   }
 
+  function setArticleNavigationContext(articles: Article[] | null): void {
+    articleNavigationContext.value = articles;
+  }
+
   function setIsFilterLoading(loading: boolean): void {
     isFilterLoading.value = loading;
   }
@@ -826,6 +839,8 @@ export const useAppStore = defineStore('app', () => {
     showOnlyUnread,
     activeFilters,
     filteredArticlesFromServer,
+    articleNavigationContext,
+    navigableArticles,
     isFilterLoading,
     articleViewModePreferences,
 
@@ -855,6 +870,7 @@ export const useAppStore = defineStore('app', () => {
     toggleShowOnlyUnread,
     setActiveFilters,
     setFilteredArticlesFromServer,
+    setArticleNavigationContext,
     setIsFilterLoading,
     fetchTaskDetails,
   };

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -28,6 +28,10 @@ export interface Article {
   summary?: string; // Cached AI-generated summary
   original_summary?: string; // Summary/description provided by the RSS item
   freshrss_item_id?: string; // FreshRSS/Google Reader item ID
+  relevance_score?: number; // AI search relevance score
+  matched_terms?: string[]; // Terms that matched this article
+  matched_fields?: Array<'title' | 'summary' | 'content'>; // Explainable match locations
+  excerpt?: string; // Sanitized AI search context excerpt
 }
 
 export interface Feed {

--- a/internal/database/article_search_db.go
+++ b/internal/database/article_search_db.go
@@ -3,10 +3,16 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	stdhtml "html"
 	"log"
+	"sort"
+	"strings"
 	"time"
+	"unicode"
 
 	"MrRSS/internal/models"
+
+	"golang.org/x/net/html"
 )
 
 // GetImageGalleryArticles retrieves articles from image mode feeds with pagination.
@@ -85,110 +91,432 @@ func (db *DB) GetImageGalleryArticles(feedID int64, category string, showHidden 
 	return articles, nil
 }
 
-// SearchArticlesWithAI executes a search query with an AI-generated WHERE clause.
-// The whereClause should be pre-validated to prevent SQL injection.
-func (db *DB) SearchArticlesWithAI(whereClause string, limit int) ([]models.Article, error) {
-	db.WaitForReady()
-
-	if limit <= 0 {
-		limit = 100
-	}
-	if limit > 500 {
-		limit = 500
-	}
-
-	// Build the complete query with the AI-generated WHERE clause
-	query := fmt.Sprintf(`
-		SELECT a.id, a.feed_id, a.title, a.url, a.image_url, a.audio_url, a.video_url,
-			   a.published_at, a.is_read, a.is_favorite, a.is_hidden, a.is_read_later,
-			   a.translated_title, a.summary, a.freshrss_item_id, f.title, a.author
-		FROM articles a
-		JOIN feeds f ON a.feed_id = f.id
-		WHERE %s
-		ORDER BY a.published_at DESC
-		LIMIT %d
-	`, whereClause, limit)
-
-	rows, err := db.Query(query)
-	if err != nil {
-		return nil, fmt.Errorf("query execution failed: %w", err)
-	}
-	defer rows.Close()
-
-	var articles []models.Article
-	for rows.Next() {
-		var a models.Article
-		var imageURL, audioURL, videoURL, translatedTitle, summary, freshrssItemID, author sql.NullString
-		var publishedAt sql.NullTime
-		if err := rows.Scan(&a.ID, &a.FeedID, &a.Title, &a.URL, &imageURL, &audioURL, &videoURL, &publishedAt, &a.IsRead, &a.IsFavorite, &a.IsHidden, &a.IsReadLater, &translatedTitle, &summary, &freshrssItemID, &a.FeedTitle, &author); err != nil {
-			log.Println("Error scanning article in AI search:", err)
-			continue
-		}
-		a.ImageURL = imageURL.String
-		a.AudioURL = audioURL.String
-		a.VideoURL = videoURL.String
-		if publishedAt.Valid {
-			a.PublishedAt = publishedAt.Time
-		} else {
-			a.PublishedAt = time.Time{}
-		}
-		a.TranslatedTitle = translatedTitle.String
-		a.Summary = summary.String
-		a.FreshRSSItemID = freshrssItemID.String
-		a.Author = author.String
-		articles = append(articles, a)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("row iteration failed: %w", err)
-	}
-
-	return articles, nil
+// AISearchQuery contains bounded terms parsed from the AI response. AI output
+// is always passed to SQLite as data and never executed as SQL.
+type AISearchQuery struct {
+	Original string
+	Required []string
+	Optional []string
+	Patterns []string
+	Limit    int
 }
 
-// SearchArticlesWithSQL executes a complete SQL query for AI search with content and relevance scoring.
-// The query should include all necessary SELECT fields and be pre-validated.
-func (db *DB) SearchArticlesWithSQL(query string) ([]models.Article, error) {
-	db.WaitForReady()
+// AISearchResult adds explainable ranking metadata without changing Article.
+type AISearchResult struct {
+	Article        models.Article
+	RelevanceScore float64
+	MatchedTerms   []string
+	MatchedFields  []string
+	Excerpt        string
+}
 
-	if query == "" {
-		return nil, fmt.Errorf("empty query")
+type aiSearchCandidate struct {
+	article     models.Article
+	content     string
+	summaryText string
+}
+
+// SearchArticlesWithTerms performs a parameterized candidate lookup and then
+// calculates a deterministic, explainable relevance score locally.
+func (db *DB) SearchArticlesWithTerms(search AISearchQuery) ([]AISearchResult, error) {
+	db.WaitForReady()
+	if search.Limit <= 0 {
+		search.Limit = 100
+	}
+	if search.Limit > 500 {
+		search.Limit = 500
 	}
 
-	rows, err := db.Query(query)
+	originalTerms := uniqueSearchTerms([]string{search.Original}, 1)
+	requiredTerms := uniqueSearchTerms(search.Required, 8)
+	plainTerms := uniqueSearchTerms(append(append([]string{}, originalTerms...), requiredTerms...), 12)
+	patternTerms := validSearchPatterns(search.Patterns, 4)
+	if len(plainTerms) == 0 && len(patternTerms) == 0 {
+		return []AISearchResult{}, nil
+	}
+
+	conditions := make([]string, 0, len(plainTerms)+len(patternTerms))
+	conditionArgs := make([]any, 0, (len(plainTerms)+len(patternTerms))*3)
+	appendCondition := func(term string, allowWildcard bool) {
+		pattern := searchLikePattern(term, allowWildcard)
+		conditions = append(conditions, `(LOWER(a.title) LIKE ? ESCAPE '\' OR LOWER(COALESCE(a.summary, '') || ' ' || COALESCE(a.original_summary, '')) LIKE ? ESCAPE '\' OR LOWER(COALESCE(c.content, '')) LIKE ? ESCAPE '\')`)
+		conditionArgs = append(conditionArgs, pattern, pattern, pattern)
+	}
+	for _, term := range plainTerms {
+		appendCondition(term, false)
+	}
+	for _, term := range patternTerms {
+		appendCondition(term, true)
+	}
+
+	// Rank candidates in SQLite before applying LIMIT. Without this preliminary
+	// ordering, a broad AI-expanded term could fill the arbitrary row set and
+	// hide a later exact-title match from the deterministic Go ranker.
+	scoreParts := make([]string, 0, 1+len(requiredTerms)+len(patternTerms))
+	scoreArgs := make([]any, 0, (1+len(requiredTerms)+len(patternTerms))*3)
+	appendScore := func(term string, allowWildcard bool, titleWeight, summaryWeight, contentWeight int) {
+		pattern := searchLikePattern(term, allowWildcard)
+		scoreParts = append(scoreParts, fmt.Sprintf(
+			`CASE WHEN LOWER(a.title) LIKE ? ESCAPE '\' THEN %d ELSE 0 END + CASE WHEN LOWER(COALESCE(a.summary, '') || ' ' || COALESCE(a.original_summary, '')) LIKE ? ESCAPE '\' THEN %d ELSE 0 END + CASE WHEN LOWER(COALESCE(c.content, '')) LIKE ? ESCAPE '\' THEN %d ELSE 0 END`,
+			titleWeight, summaryWeight, contentWeight,
+		))
+		scoreArgs = append(scoreArgs, pattern, pattern, pattern)
+	}
+	for _, term := range originalTerms {
+		appendScore(term, false, 120, 70, 30)
+	}
+	for _, term := range requiredTerms {
+		appendScore(term, false, 24, 12, 5)
+	}
+	for _, term := range patternTerms {
+		appendScore(term, true, 30, 15, 7)
+	}
+	// Optional terms never broaden the candidate set. A bounded subset only
+	// breaks ties among articles which already match the user's query or a core
+	// expansion term.
+	for _, term := range uniqueSearchTerms(search.Optional, 6) {
+		appendScore(term, false, 6, 3, 1)
+	}
+	preliminaryScore := "0"
+	if len(scoreParts) > 0 {
+		preliminaryScore = strings.Join(scoreParts, " + ")
+	}
+
+	candidateLimit := search.Limit * 2
+	if candidateLimit < 200 {
+		candidateLimit = 200
+	}
+	if candidateLimit > 500 {
+		candidateLimit = 500
+	}
+	args := append(scoreArgs, conditionArgs...)
+	args = append(args, candidateLimit)
+
+	// The limited CTE carries only article IDs and scores. Full cached bodies are
+	// loaded for at most candidateLimit rows in the outer query, rather than
+	// becoming part of the temporary sort payload.
+	query := `
+		WITH ranked_candidates AS MATERIALIZED (
+			SELECT a.id AS article_id,
+			       (` + preliminaryScore + `) AS candidate_score,
+			       a.published_at AS candidate_time
+			FROM articles a
+			LEFT JOIN article_contents c ON a.id = c.article_id
+			WHERE a.is_hidden = 0 AND (` + strings.Join(conditions, " OR ") + `)
+			ORDER BY candidate_score DESC, candidate_time DESC, a.id DESC
+			LIMIT ?
+		)
+			SELECT a.id, a.feed_id, a.title, a.url, a.image_url, a.audio_url, a.video_url,
+			       a.published_at, a.is_read, a.is_favorite, a.is_hidden,
+			       a.is_read_later, a.translated_title, a.summary, a.original_summary, a.freshrss_item_id,
+			       f.title, a.author, COALESCE(c.content, '')
+			FROM ranked_candidates ranked
+			JOIN articles a ON a.id = ranked.article_id
+			JOIN feeds f ON a.feed_id = f.id
+			LEFT JOIN article_contents c ON a.id = c.article_id
+			ORDER BY ranked.candidate_score DESC, ranked.candidate_time DESC, a.id DESC`
+
+	rows, err := db.Query(query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("query execution failed: %w", err)
+		return nil, fmt.Errorf("execute parameterized AI search: %w", err)
 	}
 	defer rows.Close()
 
-	var articles []models.Article
+	candidates := make([]aiSearchCandidate, 0)
 	for rows.Next() {
-		var a models.Article
-		var imageURL, audioURL, videoURL, translatedTitle, summary, freshrssItemID, author sql.NullString
-		var publishedAt sql.NullTime
-		var relevanceScore float64
-		if err := rows.Scan(&a.ID, &a.FeedID, &a.Title, &a.URL, &imageURL, &audioURL, &videoURL, &publishedAt, &a.IsRead, &a.IsFavorite, &a.IsHidden, &a.IsReadLater, &translatedTitle, &summary, &freshrssItemID, &a.FeedTitle, &author, &relevanceScore); err != nil {
-			log.Println("Error scanning article in AI search with SQL:", err)
+		candidate, scanErr := scanAISearchCandidate(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("scan AI search article: %w", scanErr)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate AI search articles: %w", err)
+	}
+
+	results := make([]AISearchResult, 0, len(candidates))
+	for _, candidate := range candidates {
+		result := rankAISearchCandidate(candidate, search)
+		if result.RelevanceScore > 0 {
+			results = append(results, result)
+		}
+	}
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].RelevanceScore != results[j].RelevanceScore {
+			return results[i].RelevanceScore > results[j].RelevanceScore
+		}
+		return results[i].Article.PublishedAt.After(results[j].Article.PublishedAt)
+	})
+	if len(results) > search.Limit {
+		results = results[:search.Limit]
+	}
+	return results, nil
+}
+
+func scanAISearchCandidate(rows *sql.Rows) (aiSearchCandidate, error) {
+	var candidate aiSearchCandidate
+	a := &candidate.article
+	var imageURL, audioURL, videoURL, translatedTitle, summary, originalSummary, freshrssItemID, author sql.NullString
+	var publishedAt sql.NullTime
+	if err := rows.Scan(
+		&a.ID, &a.FeedID, &a.Title, &a.URL, &imageURL, &audioURL, &videoURL,
+		&publishedAt, &a.IsRead, &a.IsFavorite, &a.IsHidden,
+		&a.IsReadLater, &translatedTitle, &summary, &originalSummary, &freshrssItemID,
+		&a.FeedTitle, &author, &candidate.content,
+	); err != nil {
+		return candidate, err
+	}
+	a.ImageURL = imageURL.String
+	a.AudioURL = audioURL.String
+	a.VideoURL = videoURL.String
+	a.TranslatedTitle = translatedTitle.String
+	a.Summary = summary.String
+	a.OriginalSummary = originalSummary.String
+	candidate.summaryText = strings.TrimSpace(summary.String + " " + originalSummary.String)
+	a.FreshRSSItemID = freshrssItemID.String
+	a.Author = author.String
+	if publishedAt.Valid {
+		a.PublishedAt = publishedAt.Time
+	}
+	return candidate, nil
+}
+
+func rankAISearchCandidate(candidate aiSearchCandidate, search AISearchQuery) AISearchResult {
+	title := cleanSearchText(candidate.article.Title)
+	summary := cleanSearchText(candidate.summaryText)
+	content := cleanSearchText(candidate.content)
+	fields := map[string]string{"title": title, "summary": summary, "content": content}
+	matchedTerms := make([]string, 0)
+	matchedFields := make([]string, 0, 3)
+	fieldSeen := make(map[string]bool)
+	score := 0.0
+
+	apply := func(term string, wildcard bool, weights map[string]float64) bool {
+		term = strings.TrimSpace(term)
+		if normalizeSearchNeedle(term) == "" {
+			return false
+		}
+		matched := false
+		for field, value := range fields {
+			if searchTermMatches(value, term, wildcard) {
+				score += weights[field]
+				matched = true
+				if !fieldSeen[field] {
+					fieldSeen[field] = true
+					matchedFields = append(matchedFields, field)
+				}
+			}
+		}
+		if matched && !containsFold(matchedTerms, term) {
+			matchedTerms = append(matchedTerms, term)
+		}
+		return matched
+	}
+
+	apply(search.Original, false, map[string]float64{"title": 36, "summary": 20, "content": 10})
+	required := uniqueSearchTerms(search.Required, 8)
+	requiredMatches := 0
+	for _, term := range required {
+		if apply(term, false, map[string]float64{"title": 14, "summary": 8, "content": 4}) {
+			requiredMatches++
+		}
+	}
+	if len(required) > 0 {
+		score += 10 * float64(requiredMatches) / float64(len(required))
+	}
+	for _, term := range uniqueSearchTerms(search.Patterns, 4) {
+		apply(term, true, map[string]float64{"title": 18, "summary": 10, "content": 5})
+	}
+	for _, term := range uniqueSearchTerms(search.Optional, 12) {
+		apply(term, false, map[string]float64{"title": 4, "summary": 2, "content": 1})
+	}
+
+	fieldOrder := map[string]int{"title": 0, "summary": 1, "content": 2}
+	sort.SliceStable(matchedFields, func(i, j int) bool {
+		return fieldOrder[matchedFields[i]] < fieldOrder[matchedFields[j]]
+	})
+	excerptSource := summary
+	if excerptSource == "" || !containsAnyFold(excerptSource, matchedTerms) {
+		excerptSource = content
+	}
+	if excerptSource == "" {
+		excerptSource = title
+	}
+
+	return AISearchResult{
+		Article:        candidate.article,
+		RelevanceScore: score,
+		MatchedTerms:   matchedTerms,
+		MatchedFields:  matchedFields,
+		Excerpt:        makeSearchExcerpt(excerptSource, matchedTerms, 220),
+	}
+}
+
+func uniqueSearchTerms(terms []string, max int) []string {
+	result := make([]string, 0, len(terms))
+	for _, term := range terms {
+		term = strings.TrimSpace(term)
+		if term == "" || len([]rune(term)) > 80 || containsFold(result, term) {
 			continue
 		}
-		a.ImageURL = imageURL.String
-		a.AudioURL = audioURL.String
-		a.VideoURL = videoURL.String
-		if publishedAt.Valid {
-			a.PublishedAt = publishedAt.Time
-		} else {
-			a.PublishedAt = time.Time{}
+		result = append(result, term)
+		if len(result) >= max {
+			break
 		}
-		a.TranslatedTitle = translatedTitle.String
-		a.Summary = summary.String
-		a.FreshRSSItemID = freshrssItemID.String
-		a.Author = author.String
-		articles = append(articles, a)
 	}
+	return result
+}
 
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("row iteration failed: %w", err)
+func validSearchPatterns(patterns []string, max int) []string {
+	result := make([]string, 0, len(patterns))
+	for _, pattern := range uniqueSearchTerms(patterns, max) {
+		// A pattern containing only '%' (or whitespace between wildcards) is
+		// equivalent to an unbounded table scan and offers no relevance evidence.
+		if normalizeSearchNeedle(pattern) == "" {
+			continue
+		}
+		result = append(result, pattern)
 	}
+	return result
+}
 
-	return articles, nil
+func containsFold(values []string, target string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeSearchNeedle(term string) string {
+	term = strings.ToLower(strings.ReplaceAll(term, "%", " "))
+	return strings.Join(strings.Fields(term), " ")
+}
+
+func containsAnyFold(text string, terms []string) bool {
+	lower := strings.ToLower(text)
+	for _, term := range terms {
+		if needle := normalizeSearchNeedle(term); needle != "" && strings.Contains(lower, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func searchLikePattern(term string, allowWildcard bool) string {
+	term = strings.ToLower(strings.TrimSpace(term))
+	var builder strings.Builder
+	for _, char := range term {
+		switch char {
+		case '\\':
+			builder.WriteString(`\\`)
+		case '_':
+			builder.WriteString(`\_`)
+		case '%':
+			if allowWildcard {
+				builder.WriteRune('%')
+			} else {
+				builder.WriteString(`\%`)
+			}
+		default:
+			builder.WriteRune(char)
+		}
+	}
+	return "%" + builder.String() + "%"
+}
+
+func searchTermMatches(text, term string, wildcard bool) bool {
+	lower := strings.ToLower(text)
+	if !wildcard || !strings.Contains(term, "%") {
+		return strings.Contains(lower, strings.ToLower(strings.TrimSpace(term)))
+	}
+	position := 0
+	for _, part := range strings.Split(strings.ToLower(term), "%") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		index := strings.Index(lower[position:], part)
+		if index < 0 {
+			return false
+		}
+		position += index + len(part)
+	}
+	return true
+}
+
+func cleanSearchText(raw string) string {
+	if strings.TrimSpace(raw) == "" {
+		return ""
+	}
+	root, err := html.Parse(strings.NewReader(raw))
+	if err != nil {
+		return strings.Join(strings.Fields(stdhtml.UnescapeString(raw)), " ")
+	}
+	var builder strings.Builder
+	var walk func(*html.Node, bool)
+	walk = func(node *html.Node, skip bool) {
+		if node.Type == html.ElementNode {
+			switch strings.ToLower(node.Data) {
+			case "script", "style", "noscript", "template":
+				skip = true
+			case "p", "div", "br", "li", "section", "article", "h1", "h2", "h3":
+				builder.WriteByte(' ')
+			}
+		}
+		if node.Type == html.TextNode && !skip {
+			builder.WriteString(node.Data)
+			builder.WriteByte(' ')
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			walk(child, skip)
+		}
+	}
+	walk(root, false)
+	return strings.Join(strings.Fields(stdhtml.UnescapeString(builder.String())), " ")
+}
+
+func makeSearchExcerpt(text string, terms []string, maxRunes int) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return text
+	}
+	lower := strings.ToLower(text)
+	matchByte := -1
+	for _, term := range terms {
+		if needle := normalizeSearchNeedle(term); needle != "" {
+			if index := strings.Index(lower, needle); index >= 0 && (matchByte < 0 || index < matchByte) {
+				matchByte = index
+			}
+		}
+	}
+	matchRune := 0
+	if matchByte > 0 {
+		matchRune = len([]rune(text[:matchByte]))
+	}
+	start := matchRune - maxRunes/3
+	if start < 0 {
+		start = 0
+	}
+	end := start + maxRunes
+	if end > len(runes) {
+		end = len(runes)
+		start = end - maxRunes
+	}
+	for start > 0 && !unicode.IsSpace(runes[start]) {
+		start--
+	}
+	prefix, suffix := "", ""
+	if start > 0 {
+		prefix = "…"
+	}
+	if end < len(runes) {
+		suffix = "…"
+	}
+	return prefix + strings.TrimSpace(string(runes[start:end])) + suffix
 }

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -475,5 +476,135 @@ func TestCleanupUnimportantArticles(t *testing.T) {
 	}
 	if secondCount != 0 {
 		t.Fatalf("Expected idempotent cleanup to delete 0 articles, deleted %d", secondCount)
+	}
+}
+
+func TestSearchArticlesWithTermsRanksAndExplainsMatches(t *testing.T) {
+	db, err := NewDB(":memory:")
+	if err != nil {
+		t.Fatalf("NewDB error: %v", err)
+	}
+	defer db.Close()
+	if err := db.Init(); err != nil {
+		t.Fatalf("Init error: %v", err)
+	}
+
+	result, err := db.Exec(`INSERT INTO feeds (url, title) VALUES (?, ?)`, "https://example.com/feed", "Example")
+	if err != nil {
+		t.Fatalf("insert feed: %v", err)
+	}
+	feedID, _ := result.LastInsertId()
+	insertArticle := func(title, originalSummary string, hidden bool) int64 {
+		t.Helper()
+		row, insertErr := db.Exec(`
+			INSERT INTO articles (feed_id, title, url, published_at, original_summary, is_hidden)
+			VALUES (?, ?, ?, ?, ?, ?)
+		`, feedID, title, "https://example.com/"+title, time.Now(), originalSummary, hidden)
+		if insertErr != nil {
+			t.Fatalf("insert article %q: %v", title, insertErr)
+		}
+		id, _ := row.LastInsertId()
+		return id
+	}
+
+	titleID := insertArticle("AI safety engineering guide", "Practical controls", false)
+	summaryID := insertArticle("Engineering notes", "A guide to AI safety evaluations", false)
+	contentID := insertArticle("Research digest", "Weekly research", false)
+	hiddenID := insertArticle("AI safety hidden article", "must stay hidden", true)
+	if err := db.SetArticleContent(contentID, `<p>Hands-on <strong>AI safety</strong> testing.</p><script>secret()</script>`); err != nil {
+		t.Fatalf("set content: %v", err)
+	}
+
+	results, err := db.SearchArticlesWithTerms(AISearchQuery{
+		Original: "AI safety",
+		Required: []string{"AI", "safety"},
+		Optional: []string{"engineering", "testing"},
+		Patterns: []string{"AI%safety"},
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 visible results, got %d: %+v", len(results), results)
+	}
+	if results[0].Article.ID != titleID {
+		t.Fatalf("expected title phrase match first, got article %d", results[0].Article.ID)
+	}
+	seen := map[int64]AISearchResult{}
+	for _, searchResult := range results {
+		seen[searchResult.Article.ID] = searchResult
+		if searchResult.Article.ID == hiddenID {
+			t.Fatal("hidden article must not be returned")
+		}
+		if searchResult.RelevanceScore <= 0 || len(searchResult.MatchedTerms) == 0 || len(searchResult.MatchedFields) == 0 {
+			t.Fatalf("missing relevance explanation: %+v", searchResult)
+		}
+	}
+	if _, ok := seen[summaryID]; !ok {
+		t.Fatal("expected original RSS summary match")
+	}
+	contentResult, ok := seen[contentID]
+	if !ok {
+		t.Fatal("expected article content match")
+	}
+	if strings.Contains(contentResult.Excerpt, "<") || strings.Contains(contentResult.Excerpt, "secret()") {
+		t.Fatalf("excerpt was not sanitized: %q", contentResult.Excerpt)
+	}
+
+	injectionResults, err := db.SearchArticlesWithTerms(AISearchQuery{
+		Original: `' OR 1=1 --`,
+		Required: []string{`%' OR 1=1 --`},
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("parameterized search rejected input unexpectedly: %v", err)
+	}
+	if len(injectionResults) != 0 {
+		t.Fatalf("SQL-like input must not broaden results: %+v", injectionResults)
+	}
+
+	// A broad expansion can match more rows than the bounded candidate set.
+	// The exact original phrase must be prioritized before LIMIT, even when it
+	// is older and inserted after all broad matches.
+	for i := 0; i < 230; i++ {
+		if _, err := db.Exec(`
+			INSERT INTO articles (feed_id, title, url, published_at, original_summary)
+			VALUES (?, ?, ?, ?, ?)
+		`, feedID, fmt.Sprintf("Broad result %03d", i), fmt.Sprintf("https://example.com/broad/%d", i), time.Now(), "common expansion"); err != nil {
+			t.Fatalf("insert broad search candidate %d: %v", i, err)
+		}
+	}
+	exactResult, err := db.Exec(`
+		INSERT INTO articles (feed_id, title, url, published_at, original_summary)
+		VALUES (?, ?, ?, ?, ?)
+	`, feedID, "rare exact phrase", "https://example.com/exact", time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC), "common expansion")
+	if err != nil {
+		t.Fatalf("insert exact search candidate: %v", err)
+	}
+	exactID, _ := exactResult.LastInsertId()
+
+	boundedResults, err := db.SearchArticlesWithTerms(AISearchQuery{
+		Original: "rare exact phrase",
+		Required: []string{"common"},
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("bounded candidate search: %v", err)
+	}
+	if len(boundedResults) == 0 || boundedResults[0].Article.ID != exactID {
+		t.Fatalf("expected exact phrase result before bounded broad matches, got %+v", boundedResults)
+	}
+
+	wildcardOnlyResults, err := db.SearchArticlesWithTerms(AISearchQuery{
+		Original: "missing literal phrase",
+		Patterns: []string{"%", " % % "},
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("wildcard-only pattern search: %v", err)
+	}
+	if len(wildcardOnlyResults) != 0 {
+		t.Fatalf("wildcard-only patterns must not broaden results: %+v", wildcardOnlyResults)
 	}
 }

--- a/internal/handlers/ai/ai_search.go
+++ b/internal/handlers/ai/ai_search.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
 
 	"MrRSS/internal/ai"
 	"MrRSS/internal/config"
+	"MrRSS/internal/database"
 	"MrRSS/internal/handlers/core"
 	"MrRSS/internal/handlers/response"
 )
@@ -22,11 +24,12 @@ type AISearchRequest struct {
 
 // AISearchResponse represents the response from AI search
 type AISearchResponse struct {
-	Success     bool             `json:"success"`
-	Articles    []map[string]any `json:"articles,omitempty"`
-	SearchTerms string           `json:"search_terms,omitempty"`
-	Error       string           `json:"error,omitempty"`
-	TotalCount  int              `json:"total_count"`
+	Success       bool             `json:"success"`
+	Articles      []map[string]any `json:"articles,omitempty"`
+	SearchTerms   string           `json:"search_terms,omitempty"`
+	ExpandedTerms *SearchTerms     `json:"expanded_terms,omitempty"`
+	Error         string           `json:"error,omitempty"`
+	TotalCount    int              `json:"total_count"`
 }
 
 // extractSearchTerms extracts the search terms from AI response
@@ -78,7 +81,55 @@ func parseSearchTermsAdvanced(response string) (*SearchTerms, error) {
 		return nil, fmt.Errorf("no search terms extracted")
 	}
 
+	terms.Required = normalizeTerms(terms.Required, 8)
+	terms.Optional = normalizeTerms(terms.Optional, 12)
+	terms.Patterns = normalizeSearchPatterns(terms.Patterns, 4)
 	return &terms, nil
+}
+
+func normalizeSearchPatterns(values []string, max int) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range normalizeTerms(values, max) {
+		plain := strings.Join(strings.Fields(strings.ReplaceAll(value, "%", " ")), " ")
+		if plain == "" {
+			continue
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func endpointForLog(rawEndpoint string) string {
+	parsed, err := url.Parse(strings.TrimSpace(rawEndpoint))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "<configured>"
+	}
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.ForceQuery = false
+	parsed.Fragment = ""
+	return parsed.String()
+}
+
+func normalizeTerms(values []string, max int) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{})
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		key := strings.ToLower(value)
+		if value == "" || len([]rune(value)) > 80 {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, value)
+		if len(result) >= max {
+			break
+		}
+	}
+	return result
 }
 
 // buildAISearchPrompt creates a concise system prompt for keyword expansion
@@ -102,95 +153,6 @@ Output: {"required":["LLM","大语言模型","large language model"],"optional":
 
 Input: "Python web框架"
 Output: {"required":["Python","web框架","web framework"],"optional":["Django","Flask","FastAPI","后端","backend"],"patterns":["Python%web","Python%框架"]}`
-}
-
-// buildSearchSQL builds the SQL query from search terms with relevance scoring
-func buildSearchSQL(terms *SearchTerms, limit int) string {
-	if terms == nil || (len(terms.Required) == 0 && len(terms.Patterns) == 0) {
-		return ""
-	}
-
-	// Build required conditions (must match at least one)
-	var requiredConditions []string
-	for _, term := range terms.Required {
-		escapedTerm := strings.ReplaceAll(term, "'", "''")
-		condition := fmt.Sprintf(
-			"(a.title LIKE '%%%s%%' OR c.content LIKE '%%%s%%' OR a.summary LIKE '%%%s%%')",
-			escapedTerm, escapedTerm, escapedTerm,
-		)
-		requiredConditions = append(requiredConditions, condition)
-	}
-
-	// Build pattern conditions
-	for _, pattern := range terms.Patterns {
-		escapedPattern := strings.ReplaceAll(pattern, "'", "''")
-		condition := fmt.Sprintf(
-			"(a.title LIKE '%%%s%%' OR c.content LIKE '%%%s%%' OR a.summary LIKE '%%%s%%')",
-			escapedPattern, escapedPattern, escapedPattern,
-		)
-		requiredConditions = append(requiredConditions, condition)
-	}
-
-	// Build relevance score with weighted scoring
-	var scoreTerms []string
-
-	// Required terms get higher base weight
-	for _, term := range terms.Required {
-		escapedTerm := strings.ReplaceAll(term, "'", "''")
-		scoreTerm := fmt.Sprintf(
-			"(CASE WHEN a.title LIKE '%%%s%%' THEN 5 ELSE 0 END + "+
-				"CASE WHEN c.content LIKE '%%%s%%' THEN 2 ELSE 0 END + "+
-				"CASE WHEN a.summary LIKE '%%%s%%' THEN 3 ELSE 0 END)",
-			escapedTerm, escapedTerm, escapedTerm,
-		)
-		scoreTerms = append(scoreTerms, scoreTerm)
-	}
-
-	// Patterns get highest weight (exact phrase match)
-	for _, pattern := range terms.Patterns {
-		escapedPattern := strings.ReplaceAll(pattern, "'", "''")
-		scoreTerm := fmt.Sprintf(
-			"(CASE WHEN a.title LIKE '%%%s%%' THEN 8 ELSE 0 END + "+
-				"CASE WHEN c.content LIKE '%%%s%%' THEN 4 ELSE 0 END + "+
-				"CASE WHEN a.summary LIKE '%%%s%%' THEN 5 ELSE 0 END)",
-			escapedPattern, escapedPattern, escapedPattern,
-		)
-		scoreTerms = append(scoreTerms, scoreTerm)
-	}
-
-	// Optional terms get lower weight
-	for _, term := range terms.Optional {
-		escapedTerm := strings.ReplaceAll(term, "'", "''")
-		scoreTerm := fmt.Sprintf(
-			"(CASE WHEN a.title LIKE '%%%s%%' THEN 2 ELSE 0 END + "+
-				"CASE WHEN c.content LIKE '%%%s%%' THEN 1 ELSE 0 END + "+
-				"CASE WHEN a.summary LIKE '%%%s%%' THEN 1 ELSE 0 END)",
-			escapedTerm, escapedTerm, escapedTerm,
-		)
-		scoreTerms = append(scoreTerms, scoreTerm)
-	}
-
-	relevanceScore := "0"
-	if len(scoreTerms) > 0 {
-		relevanceScore = strings.Join(scoreTerms, " + ")
-	}
-
-	// Build full query with LEFT JOIN to article_contents for content search
-	whereClause := strings.Join(requiredConditions, " OR ")
-	query := fmt.Sprintf(`
-		SELECT a.id, a.feed_id, a.title, a.url, a.image_url, a.audio_url, a.video_url,
-			   a.published_at, a.is_read, a.is_favorite, a.is_hidden, a.is_read_later,
-			   a.translated_title, a.summary, a.freshrss_item_id, f.title AS feed_title, a.author,
-			   (%s) AS relevance_score
-		FROM articles a
-		JOIN feeds f ON a.feed_id = f.id
-		LEFT JOIN article_contents c ON a.id = c.article_id
-		WHERE a.is_hidden = 0 AND (%s)
-		ORDER BY relevance_score DESC, a.published_at DESC
-		LIMIT %d
-	`, relevanceScore, whereClause, limit)
-
-	return query
 }
 
 // HandleAISearch handles POST /api/ai/search for AI-powered article search
@@ -228,7 +190,8 @@ func HandleAISearch(h *core.Handler, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("[AI Search] User query: %s", req.Query)
+	query := strings.TrimSpace(req.Query)
+	log.Printf("[AI Search] Starting search (query length: %d)", len([]rune(query)))
 
 	// Get AI settings - try ProfileProvider first
 	var apiKey, endpoint, model string
@@ -238,7 +201,7 @@ func HandleAISearch(h *core.Handler, w http.ResponseWriter, r *http.Request) {
 			apiKey = cfg.APIKey
 			endpoint = cfg.Endpoint
 			model = cfg.Model
-			log.Printf("[AI Search] Using AI profile for search (endpoint: %s, model: %s)", endpoint, model)
+			log.Printf("[AI Search] Using AI profile for search (endpoint: %s, model: %s)", endpointForLog(endpoint), model)
 		}
 	}
 
@@ -256,7 +219,7 @@ func HandleAISearch(h *core.Handler, w http.ResponseWriter, r *http.Request) {
 		if model == "" {
 			model = defaults.AIModel
 		}
-		log.Printf("[AI Search] Using global AI settings for search (endpoint: %s, model: %s)", endpoint, model)
+		log.Printf("[AI Search] Using global AI settings for search (endpoint: %s, model: %s)", endpointForLog(endpoint), model)
 	}
 
 	// Validate AI configuration
@@ -298,8 +261,6 @@ func HandleAISearch(h *core.Handler, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("[AI Search] AI response: %s", aiResponse)
-
 	// Parse search terms from AI response
 	searchTerms, err := parseSearchTermsAdvanced(aiResponse)
 	if err != nil {
@@ -315,14 +276,20 @@ func HandleAISearch(h *core.Handler, w http.ResponseWriter, r *http.Request) {
 	allTerms = append(allTerms, searchTerms.Required...)
 	allTerms = append(allTerms, searchTerms.Optional...)
 	allTerms = append(allTerms, searchTerms.Patterns...)
-	log.Printf("[AI Search] Required: %v, Optional: %v, Patterns: %v", searchTerms.Required, searchTerms.Optional, searchTerms.Patterns)
+	log.Printf(
+		"[AI Search] Expanded terms (required=%d optional=%d patterns=%d)",
+		len(searchTerms.Required), len(searchTerms.Optional), len(searchTerms.Patterns),
+	)
 
-	// Build and execute search query
-	searchSQL := buildSearchSQL(searchTerms, 100)
-	log.Printf("[AI Search] SQL query:\n%s", searchSQL)
-
-	// Execute search
-	articles, err := h.DB.SearchArticlesWithSQL(searchSQL)
+	// Execute a parameterized candidate query and deterministic local ranking.
+	// The AI response is never treated as SQL.
+	results, err := h.DB.SearchArticlesWithTerms(database.AISearchQuery{
+		Original: query,
+		Required: searchTerms.Required,
+		Optional: searchTerms.Optional,
+		Patterns: searchTerms.Patterns,
+		Limit:    100,
+	})
 	if err != nil {
 		log.Printf("[AI Search] Query error: %v", err)
 		response.JSON(w, AISearchResponse{
@@ -333,11 +300,12 @@ func HandleAISearch(h *core.Handler, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("[AI Search] Found %d articles", len(articles))
+	log.Printf("[AI Search] Found %d articles", len(results))
 
 	// Convert articles to response format
-	articleMaps := make([]map[string]any, len(articles))
-	for i, article := range articles {
+	articleMaps := make([]map[string]any, len(results))
+	for i, result := range results {
+		article := result.Article
 		articleMaps[i] = map[string]any{
 			"id":               article.ID,
 			"feed_id":          article.FeedID,
@@ -355,13 +323,19 @@ func HandleAISearch(h *core.Handler, w http.ResponseWriter, r *http.Request) {
 			"author":           article.Author,
 			"translated_title": article.TranslatedTitle,
 			"summary":          article.Summary,
+			"original_summary": article.OriginalSummary,
+			"relevance_score":  result.RelevanceScore,
+			"matched_terms":    result.MatchedTerms,
+			"matched_fields":   result.MatchedFields,
+			"excerpt":          result.Excerpt,
 		}
 	}
 
 	response.JSON(w, AISearchResponse{
-		Success:     true,
-		Articles:    articleMaps,
-		SearchTerms: strings.Join(allTerms, ", "),
-		TotalCount:  len(articles),
+		Success:       true,
+		Articles:      articleMaps,
+		SearchTerms:   strings.Join(allTerms, ", "),
+		ExpandedTerms: searchTerms,
+		TotalCount:    len(results),
 	})
 }


### PR DESCRIPTION
## Description

Makes AI search results explainable and navigable. AI-expanded text is now treated only as bounded query data, exact user phrases rank first, results include safe relevance evidence, and article detail navigation follows the ordered search result set in list and card layouts.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Test addition/update

## Related Issues

Fixes #1027

## Changes Made

- Replace AI-generated SQL construction with parameterized candidate lookup and deterministic local ranking.
- Return relevance score, matched terms/fields, a sanitized excerpt, and structured expanded terms without breaking existing response fields.
- Show match evidence in list/card results and use a temporary ordered navigation context for search-only articles.

## Screenshots

Not included; behavior is covered by the existing Cypress suite.

## Testing

### Test Configuration

- **OS**: macOS 26 (local); issue also reproduced on Windows 11
- **MrRSS Version**: 1.3.27 / `main@57ae66a7`
- **Go Version**: 1.27.0
- **Node Version**: 24.19.0

### Test Steps

1. `go test ./internal/database ./internal/handlers/ai`
2. `cd frontend && npm run lint`
3. `cd frontend && npm run build`
4. `cd frontend && npm exec cypress run -- --spec cypress/e2e/article-operations.cy.ts --browser electron`

The new AI-search regression passed. The same existing file still had two unrelated pre-existing failures for read/favorite filter text selectors; seven tests passed overall, including this regression.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] Relevant unit tests pass locally

## Additional Notes

No API route or database schema changes. The added response fields are backward compatible.

## Breaking Changes

None.
