### PR TITLE
fix(settings): update AI usage limit display immediately

### DIFF
--- a/frontend/cypress/e2e/settings-persistence.cy.ts
+++ b/frontend/cypress/e2e/settings-persistence.cy.ts
@@ -487,4 +487,65 @@ describe('Settings Persistence', () => {
       expect(layoutMode).to.eq('normal');
     });
   });
+
+  it('updates the AI usage limit immediately and refreshes usage while visible', () => {
+    let usage = 120;
+    let savedLimit = '20000';
+    let usageRequests = 0;
+
+    cy.intercept('GET', '/api/ai/profiles', { statusCode: 200, body: [] });
+    cy.intercept('GET', '/api/ai-usage', (req) => {
+      usageRequests += 1;
+      const limit = Number(savedLimit);
+      req.reply({
+        statusCode: 200,
+        body: {
+          usage,
+          limit,
+          limit_reached: limit > 0 && usage >= limit,
+        },
+      });
+    }).as('getAIUsage');
+    cy.intercept('POST', '/api/settings', (req) => {
+      if (req.body.ai_usage_limit !== undefined) {
+        savedLimit = String(req.body.ai_usage_limit);
+      }
+      req.reply({ statusCode: 200, body: req.body });
+    }).as('saveAIUsageLimit');
+
+    cy.clock();
+    cy.get('button')
+      .filter('[title="Settings"], [title="设置"]')
+      .should('exist')
+      .click({ force: true });
+    cy.wait('@getSettings');
+    cy.contains('button', /^AI$/i).click({ force: true });
+    cy.wait('@getAIUsage');
+
+    cy.get('[data-testid="ai-usage-status"]').should('contain.text', '120 / 20,000');
+    cy.get('[data-testid="ai-usage-limit-input"]').clear().type('400');
+    cy.get('[data-testid="ai-usage-status"]').should('contain.text', '120 / 400');
+
+    cy.tick(500);
+    cy.wait('@saveAIUsageLimit').its('request.body.ai_usage_limit').should('eq', '400');
+    cy.wait('@getAIUsage');
+    cy.get('[data-testid="ai-usage-status"]').should('contain.text', '120 / 400');
+
+    cy.then(() => {
+      usage = 300;
+    });
+    cy.tick(15_000);
+    cy.wait('@getAIUsage');
+    cy.get('[data-testid="ai-usage-status"]').should('contain.text', '300 / 400');
+
+    let requestsBeforeUnmount = 0;
+    cy.then(() => {
+      requestsBeforeUnmount = usageRequests;
+    });
+    cy.contains('button', /^(General|常规)$/i).click({ force: true });
+    cy.tick(30_000);
+    cy.then(() => {
+      expect(usageRequests).to.eq(requestsBeforeUnmount);
+    });
+  });
 });

--- a/frontend/src/components/modals/settings/ai/AIUsageSettings.vue
+++ b/frontend/src/components/modals/settings/ai/AIUsageSettings.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted, onUnmounted, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { PhChartLine, PhArrowCounterClockwise } from '@phosphor-icons/vue';
 import { SettingGroup, SettingItem, StatusBoxGroup } from '@/components/settings';
@@ -18,6 +18,13 @@ const emit = defineEmits<{
   'update:settings': [settings: SettingsData];
 }>();
 
+const usageRefreshIntervalMs = 15_000;
+let usageRefreshTimer: ReturnType<typeof setInterval> | null = null;
+let usageRequestInFlight: Promise<void> | null = null;
+let usageRefreshQueued = false;
+let usageMounted = false;
+let usageFetchErrorShown = false;
+
 // AI usage tracking
 const aiUsage = ref<{
   usage: number;
@@ -29,15 +36,41 @@ const aiUsage = ref<{
   limit_reached: false,
 });
 
-async function fetchAIUsage() {
-  try {
-    const response = await fetch('/api/ai-usage');
-    if (response.ok) {
-      aiUsage.value = await response.json();
-    }
-  } catch (e) {
-    console.error('Failed to fetch AI usage:', e);
+async function fetchAIUsage(): Promise<void> {
+  if (usageRequestInFlight) {
+    usageRefreshQueued = true;
+    return usageRequestInFlight;
   }
+
+  usageRequestInFlight = (async () => {
+    try {
+      const response = await fetch('/api/ai-usage');
+      if (!response.ok) {
+        throw new Error(`Failed to fetch AI usage: HTTP ${response.status}`);
+      }
+      const result = await response.json();
+      aiUsage.value = {
+        usage: Number.isFinite(Number(result.usage)) ? Number(result.usage) : 0,
+        limit: Number.isFinite(Number(result.limit)) ? Number(result.limit) : 0,
+        limit_reached: Boolean(result.limit_reached),
+      };
+      usageFetchErrorShown = false;
+    } catch (error) {
+      console.error('Failed to fetch AI usage:', error);
+      if (!usageFetchErrorShown) {
+        usageFetchErrorShown = true;
+        window.showToast(t('common.errors.loadingSettings'), 'error');
+      }
+    } finally {
+      usageRequestInFlight = null;
+      if (usageRefreshQueued && usageMounted) {
+        usageRefreshQueued = false;
+        queueMicrotask(() => void fetchAIUsage());
+      }
+    }
+  })();
+
+  return usageRequestInFlight;
 }
 
 async function resetAIUsage() {
@@ -50,46 +83,75 @@ async function resetAIUsage() {
 
   try {
     const response = await fetch('/api/ai-usage/reset', { method: 'POST' });
-    if (response.ok) {
-      await fetchAIUsage();
-      // Reset the local settings value as well
-      emit('update:settings', {
-        ...props.settings,
-        ai_usage_tokens: '0',
-      });
-      window.showToast(t('setting.ai.aiUsageResetSuccess'), 'success');
+    if (!response.ok) {
+      throw new Error(`Failed to reset AI usage: HTTP ${response.status}`);
     }
-  } catch (e) {
-    console.error('Failed to reset AI usage:', e);
+
+    aiUsage.value.usage = 0;
+    await fetchAIUsage();
+    // Reset the local settings value as well
+    emit('update:settings', {
+      ...props.settings,
+      ai_usage_tokens: '0',
+    });
+    window.showToast(t('setting.ai.aiUsageResetSuccess'), 'success');
+  } catch (error) {
+    console.error('Failed to reset AI usage:', error);
     window.showToast(t('setting.ai.aiUsageResetError'), 'error');
   }
 }
 
-// Calculate usage percentage
-function getUsagePercentage(): number {
-  if (aiUsage.value.limit === 0) return 0;
-  return Math.min(100, (aiUsage.value.usage / aiUsage.value.limit) * 100);
-}
+const currentUsageLimit = computed(() => {
+  const parsed = Number(props.settings.ai_usage_limit.trim());
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 0;
+});
+
+const usageLimitReached = computed(
+  () => currentUsageLimit.value > 0 && aiUsage.value.usage >= currentUsageLimit.value
+);
+
+// Calculate usage percentage from the current input value so the card updates
+// immediately, before the debounced settings request finishes.
+const usagePercentage = computed(() => {
+  if (currentUsageLimit.value === 0) return 0;
+  return Math.min(100, (aiUsage.value.usage / currentUsageLimit.value) * 100);
+});
 
 // Status box type based on usage
 const statusType = computed(() => {
-  if (aiUsage.value.limit === 0) return 'neutral';
-  if (aiUsage.value.limit_reached) return 'error';
-  const percentage = getUsagePercentage();
-  if (percentage > 80) return 'warning';
+  if (currentUsageLimit.value === 0) return 'neutral';
+  if (usageLimitReached.value) return 'error';
+  if (usagePercentage.value > 80) return 'warning';
   return 'success';
 });
 
 // Token display value
 const tokenDisplay = computed(() => {
-  if (aiUsage.value.limit > 0) {
-    return `${aiUsage.value.usage.toLocaleString()} / ${aiUsage.value.limit.toLocaleString()}`;
+  if (currentUsageLimit.value > 0) {
+    return `${aiUsage.value.usage.toLocaleString()} / ${currentUsageLimit.value.toLocaleString()}`;
   }
   return `${aiUsage.value.usage.toLocaleString()} / ∞`;
 });
 
+function handleSettingsUpdated() {
+  void fetchAIUsage();
+}
+
 onMounted(() => {
-  fetchAIUsage();
+  usageMounted = true;
+  void fetchAIUsage();
+  window.addEventListener('settings-updated', handleSettingsUpdated);
+  usageRefreshTimer = setInterval(() => void fetchAIUsage(), usageRefreshIntervalMs);
+});
+
+onUnmounted(() => {
+  usageMounted = false;
+  usageRefreshQueued = false;
+  window.removeEventListener('settings-updated', handleSettingsUpdated);
+  if (usageRefreshTimer) {
+    clearInterval(usageRefreshTimer);
+    usageRefreshTimer = null;
+  }
 });
 </script>
 
@@ -97,12 +159,13 @@ onMounted(() => {
   <SettingGroup :icon="PhChartLine" :title="t('setting.ai.aiUsage')">
     <!-- AI Usage Display -->
     <StatusBoxGroup
+      data-testid="ai-usage-status"
       class="ai-usage-status-group"
       :statuses="[
         {
           label: t('setting.ai.aiUsageTokens'),
           value: tokenDisplay,
-          unit: aiUsage.limit > 0 ? t('setting.ai.tokens') : '',
+          unit: currentUsageLimit > 0 ? t('setting.ai.tokens') : '',
           type: statusType,
         },
       ]"
@@ -112,10 +175,10 @@ onMounted(() => {
         onClick: resetAIUsage,
       }"
       :status-info="
-        aiUsage.limit > 0
+        currentUsageLimit > 0
           ? {
               label: t('common.text.progress'),
-              time: getUsagePercentage().toFixed(2) + '%',
+              time: usagePercentage.toFixed(2) + '%',
             }
           : undefined
       "
@@ -128,6 +191,7 @@ onMounted(() => {
       :description="t('setting.ai.setUsageLimitDesc')"
     >
       <input
+        data-testid="ai-usage-limit-input"
         :value="props.settings.ai_usage_limit"
         type="number"
         min="0"


### PR DESCRIPTION
## Description

Updates the AI usage card immediately while the user edits the token limit and refreshes actual usage while the AI settings page remains visible.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Test addition/update

## Related Issues

Fixes #1028

## Changes Made

- Derive the displayed denominator, percentage, and limit state from the current settings input.
- Refresh actual usage after settings updates and every 15 seconds while mounted.
- Coalesce overlapping requests, stop polling on unmount, and surface fetch/reset failures.

## Screenshots

Not included; behavior is covered by Cypress.

## Testing

### Test Configuration

- **OS**: macOS 26 (local); issue also reproduced on Windows 11
- **MrRSS Version**: 1.3.27 / `main@57ae66a7`
- **Go Version**: 1.27.0
- **Node Version**: 24.19.0

### Test Steps

1. `cd frontend && npm run lint`
2. `cd frontend && npm run build`
3. `cd frontend && npm exec cypress run -- --spec cypress/e2e/settings-persistence.cy.ts --browser electron`

Result: 8/8 tests passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] Relevant tests pass locally

## Additional Notes

No API, settings schema, or database changes.

## Breaking Changes

None.
