### PR TITLE
fix(database): retry locked article batch writes

### DIFF
--- a/internal/database/article_db.go
+++ b/internal/database/article_db.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -10,7 +11,16 @@ import (
 
 	"MrRSS/internal/models"
 	"MrRSS/internal/utils/urlutil"
+
+	"modernc.org/sqlite"
 )
+
+const saveArticlesMaxAttempts = 3
+
+var saveArticlesRetryDelays = [...]time.Duration{
+	100 * time.Millisecond,
+	250 * time.Millisecond,
+}
 
 // SaveArticle saves a single article to the database.
 func (db *DB) SaveArticle(article *models.Article) error {
@@ -45,9 +55,43 @@ func (db *DB) SaveArticles(ctx context.Context, articles []*models.Article) erro
 		}
 	}
 
+	for attempt := 1; attempt <= saveArticlesMaxAttempts; attempt++ {
+		err := db.saveArticlesOnce(ctx, articles)
+		if err == nil {
+			return nil
+		}
+		if !isRetryableSQLiteWriteError(err) || attempt == saveArticlesMaxAttempts {
+			return fmt.Errorf("save %d articles after %d attempt(s): %w", len(articles), attempt, err)
+		}
+
+		delay := saveArticlesRetryDelays[attempt-1]
+		log.Printf(
+			"SaveArticles write contention on attempt %d/%d; retrying in %s: %v",
+			attempt,
+			saveArticlesMaxAttempts,
+			delay,
+			err,
+		)
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return fmt.Errorf("save %d articles while waiting to retry: %w", len(articles), ctx.Err())
+		case <-timer.C:
+		}
+	}
+
+	return fmt.Errorf("save %d articles: retry attempts exhausted", len(articles))
+}
+
+// saveArticlesOnce performs one all-or-nothing transaction. Any error aborts
+// the batch so callers never observe a successful partial refresh.
+func (db *DB) saveArticlesOnce(ctx context.Context, articles []*models.Article) error {
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("begin transaction: %w", err)
 	}
 	defer tx.Rollback()
 
@@ -77,15 +121,15 @@ func (db *DB) SaveArticles(ctx context.Context, articles []*models.Article) erro
 			author = excluded.author
 	`)
 	if err != nil {
-		return err
+		return fmt.Errorf("prepare article upsert: %w", err)
 	}
 	defer stmt.Close()
 
-	for _, article := range articles {
+	for index, article := range articles {
 		// Check context before each insert
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return fmt.Errorf("article %d/%d: %w", index+1, len(articles), ctx.Err())
 		default:
 		}
 
@@ -128,6 +172,14 @@ func (db *DB) SaveArticles(ctx context.Context, articles []*models.Article) erro
 				article.OriginalSummary != existingOriginalSummary ||
 				article.Author != existingAuthor
 			updatePublishedAt = article.HasValidPublishedTime || articleChanged
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf(
+				"article %d/%d (feed %d): load existing state: %w",
+				index+1,
+				len(articles),
+				article.FeedID,
+				err,
+			)
 		}
 
 		updateTime := 0
@@ -136,12 +188,36 @@ func (db *DB) SaveArticles(ctx context.Context, articles []*models.Article) erro
 		}
 		_, err = stmt.ExecContext(ctx, article.FeedID, article.Title, article.URL, article.ImageURL, article.AudioURL, article.VideoURL, article.PublishedAt, article.TranslatedTitle, isRead, isFavorite, isHidden, isReadLater, article.Summary, article.OriginalSummary, uniqueID, article.Author, updateTime)
 		if err != nil {
-			log.Println("Error saving article in batch:", err)
-			// Continue even if one fails
+			return fmt.Errorf(
+				"article %d/%d (feed %d): upsert: %w",
+				index+1,
+				len(articles),
+				article.FeedID,
+				err,
+			)
 		}
 	}
 
-	return tx.Commit()
+	if err := stmt.Close(); err != nil {
+		return fmt.Errorf("close article upsert statement: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
+	}
+	return nil
+}
+
+func isRetryableSQLiteWriteError(err error) bool {
+	var sqliteErr *sqlite.Error
+	if !errors.As(err, &sqliteErr) {
+		return false
+	}
+
+	// SQLite extended result codes retain the primary result in the low byte.
+	// This covers SQLITE_BUSY (5), SQLITE_LOCKED (6), and variants such as
+	// SQLITE_BUSY_SNAPSHOT (517).
+	primaryCode := sqliteErr.Code() & 0xff
+	return primaryCode == 5 || primaryCode == 6
 }
 
 // GetArticles retrieves articles with filtering, pagination, and sorting.

--- a/internal/database/article_db_test.go
+++ b/internal/database/article_db_test.go
@@ -2,7 +2,11 @@ package database_test
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
+	"log"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -415,6 +419,122 @@ func TestSaveArticlesBatchContextCancel(t *testing.T) {
 
 	if err := db.SaveArticles(ctx, articles); err == nil {
 		t.Fatalf("expected error due to canceled context")
+	}
+}
+
+func TestSaveArticlesRollsBackEntireBatchOnPermanentError(t *testing.T) {
+	db := setupDBWithFeed(t)
+
+	var feedID int64
+	if err := db.QueryRow(`SELECT id FROM feeds WHERE url = ?`, "https://example.com/feed").Scan(&feedID); err != nil {
+		t.Fatalf("scan feed id: %v", err)
+	}
+
+	articles := []*models.Article{
+		{
+			FeedID:                feedID,
+			Title:                 "valid article must be rolled back",
+			URL:                   "https://example.com/atomic-valid",
+			PublishedAt:           time.Now().UTC(),
+			HasValidPublishedTime: true,
+		},
+		{
+			FeedID:                feedID + 10000,
+			Title:                 "invalid feed",
+			URL:                   "https://example.com/atomic-invalid",
+			PublishedAt:           time.Now().UTC(),
+			HasValidPublishedTime: true,
+		},
+	}
+
+	err := db.SaveArticles(context.Background(), articles)
+	if err == nil {
+		t.Fatal("expected the invalid foreign key to fail the batch")
+	}
+	if !strings.Contains(err.Error(), "article 2/2") || !strings.Contains(err.Error(), "attempt(s)") {
+		t.Fatalf("expected batch and attempt context, got %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM articles WHERE url IN (?, ?)`, articles[0].URL, articles[1].URL).Scan(&count); err != nil {
+		t.Fatalf("count batch articles: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("batch committed partially: got %d stored articles, want 0", count)
+	}
+}
+
+func TestSaveArticlesRetriesSQLiteWriteContention(t *testing.T) {
+	databasePath := filepath.Join(t.TempDir(), "write-contention.db")
+	db, err := dbpkg.NewDB(databasePath)
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := db.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	if _, err := db.Exec(`PRAGMA busy_timeout = 1`); err != nil {
+		t.Fatalf("set short busy timeout: %v", err)
+	}
+	result, err := db.Exec(`INSERT INTO feeds (title, url, category) VALUES (?, ?, ?)`, "Locked Feed", "https://example.com/locked-feed", "news")
+	if err != nil {
+		t.Fatalf("insert feed: %v", err)
+	}
+	feedID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("feed id: %v", err)
+	}
+
+	locker, err := dbpkg.NewDB(databasePath)
+	if err != nil {
+		t.Fatalf("NewDB locker: %v", err)
+	}
+	t.Cleanup(func() { _ = locker.Close() })
+	lockTx, err := locker.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("begin lock transaction: %v", err)
+	}
+	if _, err := lockTx.Exec(`UPDATE settings SET value = value WHERE key = 'theme'`); err != nil {
+		t.Fatalf("acquire write lock: %v", err)
+	}
+
+	previousLogWriter := log.Writer()
+	var retryLog strings.Builder
+	log.SetOutput(&retryLog)
+	t.Cleanup(func() { log.SetOutput(previousLogWriter) })
+
+	releaseDone := make(chan error, 1)
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		releaseDone <- lockTx.Rollback()
+	}()
+
+	article := &models.Article{
+		FeedID:                feedID,
+		Title:                 "saved after lock retry",
+		URL:                   "https://example.com/saved-after-lock-retry",
+		PublishedAt:           time.Now().UTC(),
+		HasValidPublishedTime: true,
+	}
+	if err := db.SaveArticles(context.Background(), []*models.Article{article}); err != nil {
+		t.Fatalf("SaveArticles after temporary lock: %v", err)
+	}
+	if err := <-releaseDone; err != nil && !errors.Is(err, sql.ErrTxDone) {
+		t.Fatalf("release lock: %v", err)
+	}
+	if !strings.Contains(retryLog.String(), "retrying") {
+		t.Fatalf("expected a contention retry, logs: %s", retryLog.String())
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM articles WHERE url = ?`, article.URL).Scan(&count); err != nil {
+		t.Fatalf("count retried article: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("retried article count = %d, want 1", count)
 	}
 }
 

--- a/internal/feed/intelligent_refresh_test.go
+++ b/internal/feed/intelligent_refresh_test.go
@@ -2,12 +2,24 @@ package feed
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"MrRSS/internal/database"
 	"MrRSS/internal/models"
 )
+
+func addIntelligentRefreshTestFeed(t *testing.T, db *database.DB) models.Feed {
+	t.Helper()
+	feed := models.Feed{Title: "Test Feed", URL: "https://example.com/test-feed", Type: "rss"}
+	feedID, err := db.AddFeed(&feed)
+	if err != nil {
+		t.Fatalf("AddFeed error: %v", err)
+	}
+	feed.ID = feedID
+	return feed
+}
 
 func TestIntelligentRefreshCalculator_NoArticles(t *testing.T) {
 	tmpFile := t.TempDir() + "/test.db"
@@ -21,7 +33,7 @@ func TestIntelligentRefreshCalculator_NoArticles(t *testing.T) {
 	defer db.Close()
 
 	calculator := NewIntelligentRefreshCalculator(db)
-	feed := models.Feed{ID: 1, Title: "Test Feed"}
+	feed := addIntelligentRefreshTestFeed(t, db)
 
 	// Test with no articles - should return default interval
 	interval := calculator.CalculateInterval(feed)
@@ -57,17 +69,18 @@ func TestIntelligentRefreshCalculator_Bounds(t *testing.T) {
 	defer db.Close()
 
 	calculator := NewIntelligentRefreshCalculator(db)
-	feed := models.Feed{ID: 1, Title: "Test Feed"}
+	feed := addIntelligentRefreshTestFeed(t, db)
 
 	// Create articles with very high frequency (every 10 seconds)
 	now := time.Now()
 	articles := make([]*models.Article, 10)
 	for i := 0; i < 10; i++ {
 		articles[i] = &models.Article{
-			FeedID:      1,
-			Title:       "Article",
-			URL:         "http://example.com/article",
-			PublishedAt: now.Add(time.Duration(-i) * 10 * time.Second),
+			FeedID:                feed.ID,
+			Title:                 fmt.Sprintf("Article %d", i),
+			URL:                   fmt.Sprintf("http://example.com/article/%d", i),
+			PublishedAt:           now.Add(time.Duration(-i) * 10 * time.Second),
+			HasValidPublishedTime: true,
 		}
 	}
 
@@ -100,17 +113,18 @@ func TestIntelligentRefreshCalculator_LowFrequency(t *testing.T) {
 	defer db.Close()
 
 	calculator := NewIntelligentRefreshCalculator(db)
-	feed := models.Feed{ID: 1, Title: "Test Feed"}
+	feed := addIntelligentRefreshTestFeed(t, db)
 
 	// Create articles with very low frequency (every 48 hours)
 	now := time.Now()
 	articles := make([]*models.Article, 10)
 	for i := 0; i < 10; i++ {
 		articles[i] = &models.Article{
-			FeedID:      1,
-			Title:       "Article",
-			URL:         "http://example.com/article",
-			PublishedAt: now.Add(time.Duration(-i) * 48 * time.Hour),
+			FeedID:                feed.ID,
+			Title:                 fmt.Sprintf("Article %d", i),
+			URL:                   fmt.Sprintf("http://example.com/article/%d", i),
+			PublishedAt:           now.Add(time.Duration(-i) * 48 * time.Hour),
+			HasValidPublishedTime: true,
 		}
 	}
 
@@ -156,17 +170,18 @@ func TestIntelligentRefreshCalculator_WithArticles(t *testing.T) {
 	defer db.Close()
 
 	calculator := NewIntelligentRefreshCalculator(db)
-	feed := models.Feed{ID: 1, Title: "Test Feed"}
+	feed := addIntelligentRefreshTestFeed(t, db)
 
 	// Create articles published every 2 hours
 	now := time.Now()
 	articles := make([]*models.Article, 20)
 	for i := 0; i < 20; i++ {
 		articles[i] = &models.Article{
-			FeedID:      1,
-			Title:       "Article",
-			URL:         "http://example.com/article",
-			PublishedAt: now.Add(time.Duration(-i*2) * time.Hour),
+			FeedID:                feed.ID,
+			Title:                 fmt.Sprintf("Article %d", i),
+			URL:                   fmt.Sprintf("http://example.com/article/%d", i),
+			PublishedAt:           now.Add(time.Duration(-i*2) * time.Hour),
+			HasValidPublishedTime: true,
 		}
 	}
 


### PR DESCRIPTION
## Description

Makes `SaveArticles` atomic under SQLite write contention. Temporary BUSY/LOCKED failures retry the complete transaction with bounded backoff; permanent or exhausted failures roll back and propagate contextual errors to refresh callers.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Test addition/update

## Related Issues

Fixes #1029

## Changes Made

- Stop swallowing per-article write failures and committing partial feed batches.
- Retry BUSY/LOCKED primary codes, including extended codes such as BUSY_SNAPSHOT.
- Preserve user-controlled article state and related cached content during successful upserts.
- Correct existing intelligent-refresh fixtures that previously relied on swallowed foreign-key/deduplication errors.

## Screenshots

Not applicable.

## Testing

### Test Configuration

- **OS**: macOS 26 (local); issue also observed from Windows 11 logs
- **MrRSS Version**: 1.3.27 / `main@57ae66a7`
- **Go Version**: 1.27.0
- **Node Version**: 24.19.0

### Test Steps

1. `go test ./internal/database ./internal/feed`
2. Verify permanent errors roll back every row.
3. Hold a second-connection write lock, release it during retry, and verify the full batch is saved once.

Result: database and feed packages passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented the contention and transaction behavior
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] Relevant unit tests pass locally

## Additional Notes

No database schema or API changes.

## Breaking Changes

None.
