### PR TITLE
fix(refresh): support long automatic refresh intervals

### DIFF
--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -8,6 +8,7 @@ import en from './i18n/locales/en';
 import App from './App.vue';
 import { setSettingsFromRawData } from './composables/core/useSettings';
 import { getRecommendedFonts } from './utils/fontDetector';
+import { createAutoRefreshScheduler, getAutoRefreshInterval } from './stores/app';
 
 // Create stub components for complex child components
 const createStub = (name: string) => ({
@@ -16,6 +17,89 @@ const createStub = (name: string) => ({
 });
 
 describe('App', () => {
+  it('schedules normal and very long automatic refresh intervals without overflowing', async () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn();
+    const scheduler = createAutoRefreshScheduler(refresh);
+
+    scheduler.start(30);
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000 - 1);
+    expect(refresh).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    refresh.mockClear();
+    scheduler.start(46_080);
+    await vi.advanceTimersByTimeAsync(46_080 * 60 * 1000 - 1);
+    expect(refresh).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    scheduler.stop();
+    vi.useRealTimers();
+  });
+
+  it('replaces or disables an existing automatic refresh schedule', async () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn();
+    const scheduler = createAutoRefreshScheduler(refresh);
+
+    scheduler.start(30);
+    await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
+    scheduler.start(60);
+    await vi.advanceTimersByTimeAsync(45 * 60 * 1000);
+    expect(refresh).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    refresh.mockClear();
+    scheduler.start(30);
+    scheduler.start(0);
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(refresh).not.toHaveBeenCalled();
+
+    scheduler.stop();
+    vi.useRealTimers();
+  });
+
+  it('disables the frontend timer outside fixed refresh mode', () => {
+    expect(getAutoRefreshInterval('fixed', 30)).toBe(30);
+    expect(getAutoRefreshInterval('intelligent', 30)).toBe(0);
+    expect(getAutoRefreshInterval('never', 30)).toBe(0);
+  });
+
+  it('skips overlapping refreshes and catches up only once after sleep', async () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn();
+    let refreshing = true;
+    let currentTime = 0;
+    const scheduler = createAutoRefreshScheduler(
+      refresh,
+      () => !refreshing,
+      () => currentTime
+    );
+
+    scheduler.start(30);
+    currentTime = 30 * 60 * 1000;
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+    expect(refresh).not.toHaveBeenCalled();
+
+    refreshing = false;
+    currentTime = 4 * 30 * 60 * 1000;
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    currentTime = 5 * 30 * 60 * 1000;
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+    vi.useRealTimers();
+  });
+
   it('keeps long toast messages inside narrow viewports', () => {
     const toast = readFileSync('src/components/common/Toast.vue', 'utf8');
     expect(toast).toContain('calc(100vw-2rem)');

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useAppStore } from './stores/app';
+import { getAutoRefreshInterval, useAppStore } from './stores/app';
 import { useI18n } from 'vue-i18n';
 import Sidebar from './components/sidebar/Sidebar.vue';
 import ArticleList from './components/article/ArticleList.vue';
@@ -124,6 +124,7 @@ onMounted(async () => {
 
   // Load remaining settings (theme and other settings are already loaded in main.ts)
   let updateInterval = 10;
+  let refreshMode = 'fixed';
   let lastGlobalRefresh = '';
   let updateCheckEnabled = true;
 
@@ -148,10 +149,11 @@ onMounted(async () => {
     }
 
     // Apply other settings
+    refreshMode = data.refresh_mode || 'fixed';
     if (data.update_interval) {
       updateInterval = parseInt(data.update_interval);
-      store.startAutoRefresh(updateInterval);
     }
+    store.startAutoRefresh(getAutoRefreshInterval(refreshMode, updateInterval));
 
     if (data.last_global_refresh) {
       lastGlobalRefresh = data.last_global_refresh;
@@ -233,7 +235,8 @@ onMounted(async () => {
         console.error('Error fetching latest last_global_refresh:', e);
       }
 
-      const shouldRefresh = shouldTriggerRefresh(latestLastGlobalRefresh, updateInterval);
+      const shouldRefresh =
+        refreshMode === 'fixed' && shouldTriggerRefresh(latestLastGlobalRefresh, updateInterval);
       if (shouldRefresh) {
         store.refreshFeeds();
       }

--- a/frontend/src/composables/core/useSettingsAutoSave.ts
+++ b/frontend/src/composables/core/useSettingsAutoSave.ts
@@ -3,7 +3,7 @@
  */
 import { ref, watch, onMounted, onUnmounted, type Ref, computed, isRef } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useAppStore } from '@/stores/app';
+import { getAutoRefreshInterval, useAppStore } from '@/stores/app';
 import type { SettingsData } from '@/types/settings';
 import { settingsDefaults } from '@/config/defaults';
 import { buildAutoSavePayload } from './useSettings.generated';
@@ -97,7 +97,9 @@ export function useSettingsAutoSave(settings: Ref<SettingsData> | (() => Setting
       // even if validation fails - these don't require API keys
       locale.value = settingsRef.value.language;
       store.setTheme(settingsRef.value.theme as 'light' | 'dark' | 'auto');
-      store.startAutoRefresh(settingsRef.value.update_interval);
+      store.startAutoRefresh(
+        getAutoRefreshInterval(settingsRef.value.refresh_mode, settingsRef.value.update_interval)
+      );
 
       // Notify components about default view mode change
       window.dispatchEvent(

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -8,6 +8,93 @@ export type Filter = 'all' | 'unread' | 'favorites' | 'readLater' | 'imageGaller
 export type ThemePreference = 'light' | 'dark' | 'auto';
 export type Theme = 'light' | 'dark';
 
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+const MINUTE_MS = 60_000;
+
+interface AutoRefreshScheduler {
+  start: (minutes: number) => void;
+  stop: () => void;
+}
+
+export function getAutoRefreshInterval(refreshMode: string, minutes: number): number {
+  return refreshMode === 'fixed' ? minutes : 0;
+}
+
+export function createAutoRefreshScheduler(
+  onRefresh: () => void | Promise<void>,
+  canRefresh: () => boolean = () => true,
+  now: () => number = Date.now
+): AutoRefreshScheduler {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let intervalMs = 0;
+  let nextRefreshAt = 0;
+  let generation = 0;
+
+  const clearTimer = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const schedule = (currentGeneration: number) => {
+    if (currentGeneration !== generation || intervalMs <= 0) {
+      return;
+    }
+
+    const remaining = Math.max(0, nextRefreshAt - now());
+    timer = setTimeout(
+      () => {
+        timer = null;
+        if (currentGeneration !== generation || intervalMs <= 0) {
+          return;
+        }
+
+        const currentTime = now();
+        if (currentTime < nextRefreshAt) {
+          schedule(currentGeneration);
+          return;
+        }
+
+        // Advance directly to the next future deadline. If the computer slept
+        // across several intervals, this triggers one catch-up refresh instead
+        // of replaying every missed interval.
+        const missedIntervals = Math.floor((currentTime - nextRefreshAt) / intervalMs);
+        nextRefreshAt += (missedIntervals + 1) * intervalMs;
+        schedule(currentGeneration);
+
+        if (canRefresh()) {
+          void onRefresh();
+        }
+      },
+      Math.min(remaining, MAX_TIMER_DELAY_MS)
+    );
+  };
+
+  const stop = () => {
+    generation += 1;
+    intervalMs = 0;
+    nextRefreshAt = 0;
+    clearTimer();
+  };
+
+  return {
+    start(minutes: number) {
+      stop();
+
+      const requestedInterval = minutes * MINUTE_MS;
+      if (!Number.isFinite(requestedInterval) || requestedInterval <= 0) {
+        return;
+      }
+
+      intervalMs = requestedInterval;
+      nextRefreshAt = now() + intervalMs;
+      schedule(generation);
+    },
+    stop,
+  };
+}
+
 // Temporary selection state for feed drawer selections
 export interface TempSelection {
   feedId: number | null;
@@ -119,7 +206,6 @@ export const useAppStore = defineStore('app', () => {
 
   // Refresh progress
   const refreshProgress = ref<RefreshProgress>({ isRunning: false });
-  let refreshInterval: ReturnType<typeof setInterval> | null = null;
   let latestFeedsRequestId = 0;
   let activeFeedsRequests = 0;
 
@@ -792,16 +878,13 @@ export const useAppStore = defineStore('app', () => {
     }
   }
 
+  const autoRefreshScheduler = createAutoRefreshScheduler(
+    refreshFeeds,
+    () => !refreshProgress.value.isRunning
+  );
+
   function startAutoRefresh(minutes: number): void {
-    if (refreshInterval) clearInterval(refreshInterval);
-    if (minutes > 0) {
-      refreshInterval = setInterval(
-        () => {
-          refreshFeeds();
-        },
-        minutes * 60 * 1000
-      );
-    }
+    autoRefreshScheduler.start(minutes);
   }
 
   function toggleShowOnlyUnread(): void {


### PR DESCRIPTION
## Summary

- replace oversized setInterval scheduling with chunked recursive setTimeout scheduling
- cap each wait at the browser timer limit while retaining the real deadline
- refresh once after sleep instead of catching up repeatedly
- cancel stale schedules when settings change or automatic refresh is disabled
- skip duplicate triggers while a refresh is already running

Fixes #1046

## Validation

- target Vitest: 7/7
- full frontend Vitest: 85/85
- full frontend ESLint and Prettier checks
- Vite production build
- git diff --check