### PR TITLE
fix：统一未读完成提示并居中显示

### DIFF
--- a/frontend/cypress/e2e/reading-interactions.cy.ts
+++ b/frontend/cypress/e2e/reading-interactions.cy.ts
@@ -16,7 +16,7 @@ const article = {
   image_url: image,
 };
 
-function setup(overrides: Record<string, string> = {}, feedMode = 'global') {
+function setup(overrides: Record<string, string> = {}, feedMode = 'global', empty = false) {
   const settings: Record<string, string> = {
     language: 'en-US',
     theme: 'light',
@@ -53,8 +53,8 @@ function setup(overrides: Record<string, string> = {}, feedMode = 'global') {
   ]).as('feeds');
   cy.intercept('GET', '/api/tags', []);
   cy.intercept('GET', '/api/saved-filters', []);
-  cy.intercept({ method: 'GET', pathname: '/api/articles' }, [article]).as('articles');
-  cy.intercept('GET', '/api/articles/images*', [article]).as('images');
+  cy.intercept({ method: 'GET', pathname: '/api/articles' }, empty ? [] : [article]).as('articles');
+  cy.intercept('GET', '/api/articles/images*', empty ? [] : [article]).as('images');
   cy.intercept('GET', '/api/articles/extract-images*', { images: [image] });
   cy.intercept('GET', '/api/articles/unread-counts', {});
   cy.intercept('GET', '/api/articles/filter-counts', {});
@@ -76,6 +76,53 @@ function openArticle() {
 }
 
 describe('Reading interactions', () => {
+  for (const [language, unreadTitle, galleryTitle, unreadToggle, emptyText, completedText] of [
+    [
+      'en-US',
+      'Unread',
+      'Multimedia Gallery',
+      'Show only unread articles',
+      'No articles found.',
+      "You're all caught up",
+    ],
+    ['zh-CN', '未读', '多媒体模式', '仅显示未读文章', '未找到文章', '已读完全部文章'],
+  ]) {
+    it(`centers unread completion and distinguishes ordinary empty galleries in ${language}`, () => {
+      setup({ language, translation_enabled: 'false' }, 'global', true);
+      cy.get('[data-testid="article-list-empty"]').should('contain', emptyText);
+      cy.get(`.smart-activity-bar button[title^="${unreadTitle}"]`).click();
+      cy.get('[data-testid="article-list-empty"]')
+        .should('contain', completedText)
+        .then(($empty) => {
+          const element = $empty[0];
+          const viewport = element.parentElement!.getBoundingClientRect();
+          const first = element.firstElementChild!.getBoundingClientRect();
+          const last = element.lastElementChild!.getBoundingClientRect();
+          expect(
+            Math.abs((first.top + last.bottom) / 2 - (viewport.top + viewport.bottom) / 2)
+          ).to.be.lessThan(3);
+        });
+      cy.get(`.smart-activity-bar button[title="${galleryTitle}"]`).click();
+      cy.wait('@images');
+      cy.get('[data-testid="gallery-empty"]')
+        .should('contain', emptyText)
+        .and('not.contain', completedText);
+      cy.get(`button[title="${unreadToggle}"]`).click();
+      cy.wait('@images').its('request.url').should('contain', 'only_unread=true');
+      cy.get('[data-testid="gallery-empty"]')
+        .should('contain', completedText)
+        .then(($empty) => {
+          const element = $empty[0];
+          const viewport = element.parentElement!.getBoundingClientRect();
+          const first = element.firstElementChild!.getBoundingClientRect();
+          const last = element.lastElementChild!.getBoundingClientRect();
+          expect(
+            Math.abs((first.top + last.bottom) / 2 - (viewport.top + viewport.bottom) / 2)
+          ).to.be.lessThan(3);
+        });
+    });
+  }
+
   it('translates only the requested title or paragraph in manual mode, and retries failures', () => {
     let calls = 0;
     let paragraphCalls = 0;

--- a/frontend/src/components/article/ArticleList.vue
+++ b/frontend/src/components/article/ArticleList.vue
@@ -1170,7 +1170,8 @@ async function markAllVisibleAsRead(): Promise<void> {
         v-if="
           filteredArticles.length === 0 && !store.isLoading && !isFilterLoading && !isAISearchActive
         "
-        class="flex flex-col items-center p-6 sm:p-8 text-center text-text-secondary"
+        class="flex min-h-full flex-col items-center justify-center p-6 sm:p-8 text-center text-text-secondary"
+        data-testid="article-list-empty"
       >
         <template v-if="isUnreadEmptyState">
           <PhCheckCircle :size="40" weight="duotone" class="mb-3 text-green-500" />

--- a/frontend/src/components/article/imageGallery/components/ImageGalleryGrid.vue
+++ b/frontend/src/components/article/imageGallery/components/ImageGalleryGrid.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
 import { ref, watch } from 'vue';
-import { PhImage } from '@phosphor-icons/vue';
+import { PhCheckCircle, PhImage } from '@phosphor-icons/vue';
 import type { Article } from '@/types/models';
 import ImageCard from './ImageCard.vue';
 
@@ -9,6 +9,7 @@ interface Props {
   columns: Article[][];
   imageDimensions: Map<number, { width: number; height: number }>;
   isLoading: boolean;
+  showOnlyUnread: boolean;
   showTextOverlay: boolean;
   imageCountCache: Map<number, number>;
 }
@@ -78,10 +79,20 @@ function getImageCount(article: Article): number {
     <!-- Empty State -->
     <div
       v-else-if="!isLoading"
-      class="flex flex-col items-center justify-center h-full w-full gap-4"
+      class="flex min-h-full w-full flex-col items-center justify-center p-6 text-center text-text-secondary"
+      data-testid="gallery-empty"
     >
-      <PhImage :size="64" class="text-text-secondary opacity-50" />
-      <p class="text-text-secondary">{{ t('article.content.noArticles') }}</p>
+      <template v-if="showOnlyUnread">
+        <PhCheckCircle :size="40" weight="duotone" class="mb-3 text-green-500" />
+        <div class="text-base font-medium text-text-primary">
+          {{ t('article.list.allCaughtUp') }}
+        </div>
+        <div class="mt-1 text-sm">{{ t('article.list.noUnreadArticles') }}</div>
+      </template>
+      <template v-else>
+        <PhImage :size="64" class="mb-4 opacity-50" />
+        <p>{{ t('article.content.noArticles') }}</p>
+      </template>
     </div>
 
     <!-- Loading Indicator -->

--- a/frontend/src/components/article/imageGallery/index.vue
+++ b/frontend/src/components/article/imageGallery/index.vue
@@ -510,6 +510,7 @@ onUnmounted(() => {
       :columns="masonryLayout.columns.value"
       :image-dimensions="masonryLayout.imageDimensions.value"
       :is-loading="galleryData.isLoading.value"
+      :show-only-unread="galleryData.showOnlyUnread.value"
       :show-text-overlay="showTextOverlay"
       :image-count-cache="galleryData.imageCountCache.value"
       @image-size="masonryLayout.setImageSize"


### PR DESCRIPTION
未读列表清空后，完成提示缺少垂直居中；多媒体模式也仍使用普通“未找到文章”空状态。

现在普通列表和多媒体列表都将未读完成提示置于可用区域中央。多媒体列表只在“仅显示未读文章”开启时显示完成提示，普通空列表保留原有无内容文案。

验证：新增中英文位置及空状态回归，阅读交互 Cypress 8/8、前端单测 119/119、ESLint、前端构建、wails3 build、pre-commit 和 git diff --check 通过。ESLint 存在官方基线已有的格式警告，无错误；本地 Node 26 单测使用 --no-experimental-webstorage 以匹配 CI 的浏览器存储环境。

Closes #1099
