### PR TITLE
fix：记住 AI 聊天面板尺寸并适配窗口大小

### DIFF
--- a/frontend/cypress/e2e/reading-interactions.cy.ts
+++ b/frontend/cypress/e2e/reading-interactions.cy.ts
@@ -16,7 +16,11 @@ const article = {
   image_url: image,
 };
 
-function setup(overrides: Record<string, string> = {}, feedMode = 'global') {
+function setup(
+  overrides: Record<string, string> = {},
+  feedMode = 'global',
+  savedState: Record<string, string> = {}
+) {
   const settings: Record<string, string> = {
     language: 'en-US',
     theme: 'light',
@@ -65,7 +69,11 @@ function setup(overrides: Record<string, string> = {}, feedMode = 'global') {
     cached: true,
   }).as('content');
   cy.intercept('POST', '/api/browser/open', { statusCode: 200, body: {} }).as('openBrowser');
-  cy.visit('/');
+  cy.visit('/', {
+    onBeforeLoad(win) {
+      Object.entries(savedState).forEach(([key, value]) => win.localStorage.setItem(key, value));
+    },
+  });
   cy.wait(['@feeds', '@articles']);
 }
 
@@ -187,5 +195,102 @@ describe('Reading interactions', () => {
     cy.contains('English title').click();
     cy.get('[role="dialog"][aria-modal="true"]').should('be.visible');
     cy.get('@openBrowser.all').should('have.length', 0);
+  });
+
+  it('remembers the measured chat size after dragging, closing, reopening, and reloading', () => {
+    cy.viewport(1280, 900);
+    setup({ ai_chat_enabled: 'true' }, 'global', { FeedListExpanded: 'false' });
+    cy.intercept('GET', '/api/ai/profiles', []);
+    cy.intercept('GET', '/api/ai/chat/sessions*', []);
+    openArticle();
+    cy.get('.js-article-chat-button').click();
+    cy.get('.chat-panel')
+      .should(($panel) => {
+        const rect = $panel[0].getBoundingClientRect();
+        expect(rect.width).to.equal(500);
+        expect(rect.height).to.equal(600);
+      })
+      .then(($panel) => {
+        const rect = $panel[0].getBoundingClientRect();
+        cy.get('.chat-panel .cursor-nw-resize').trigger('mousedown', {
+          clientX: rect.left + 2,
+          clientY: rect.top + 2,
+          button: 0,
+          force: true,
+        });
+        cy.document().trigger('mousemove', { clientX: rect.left - 118, clientY: rect.top - 98 });
+      });
+    cy.get('.chat-panel').should(($panel) => {
+      const rect = $panel[0].getBoundingClientRect();
+      expect(rect.width).to.equal(620);
+      expect(rect.height).to.equal(700);
+    });
+    cy.window().then((win) => expect(win.localStorage.getItem('mrrssChatPanelSize')).to.be.null);
+    cy.document().trigger('mouseup');
+    cy.window().then((win) => {
+      expect(JSON.parse(win.localStorage.getItem('mrrssChatPanelSize')!)).to.deep.equal({
+        width: 620,
+        height: 700,
+      });
+    });
+    cy.get('.chat-panel button[title="Close"]').click();
+    cy.get('.chat-panel').should('not.exist');
+    cy.get('.js-article-chat-button').click();
+    cy.get('.chat-panel').should(($panel) => {
+      const rect = $panel[0].getBoundingClientRect();
+      expect(rect.width).to.equal(620);
+      expect(rect.height).to.equal(700);
+    });
+    cy.reload();
+    openArticle();
+    cy.get('.js-article-chat-button').click();
+    cy.get('.chat-panel').should(($panel) => {
+      const rect = $panel[0].getBoundingClientRect();
+      expect(rect.width).to.equal(620);
+      expect(rect.height).to.equal(700);
+    });
+  });
+
+  it('temporarily fits a narrow viewport without replacing the preferred chat size', () => {
+    cy.viewport(1280, 900);
+    const preferred = { width: 680, height: 720 };
+    setup({ ai_chat_enabled: 'true' }, 'global', {
+      FeedListExpanded: 'false',
+      mrrssChatPanelSize: JSON.stringify(preferred),
+    });
+    cy.intercept('GET', '/api/ai/profiles', []);
+    cy.intercept('GET', '/api/ai/chat/sessions*', []);
+    openArticle();
+    cy.get('.js-article-chat-button').click();
+    cy.viewport(390, 500);
+    cy.get('.chat-panel').should(($panel) => {
+      const rect = $panel[0].getBoundingClientRect();
+      expect(rect.width).to.equal(358);
+      expect(rect.height).to.equal(444);
+      expect(rect.left).to.be.at.least(0);
+      expect(rect.top).to.be.at.least(0);
+      expect(rect.right).to.be.at.most(390);
+      expect(rect.bottom).to.be.at.most(500);
+    });
+    cy.get('.chat-panel button[title="Close"]').click();
+    cy.get('.chat-panel').should('not.exist');
+    cy.get('.js-article-chat-button').click();
+    cy.get('.chat-panel').should(($panel) => {
+      const rect = $panel[0].getBoundingClientRect();
+      expect(rect.width).to.equal(358);
+      expect(rect.height).to.equal(444);
+    });
+    cy.window().then((win) => {
+      expect(JSON.parse(win.localStorage.getItem('mrrssChatPanelSize')!)).to.deep.equal(preferred);
+    });
+    cy.viewport(1280, 900);
+    cy.get('.chat-panel').should(($panel) => {
+      const rect = $panel[0].getBoundingClientRect();
+      expect(rect.width).to.equal(preferred.width);
+      expect(rect.height).to.equal(preferred.height);
+    });
+    cy.window().then((win) => {
+      expect(JSON.parse(win.localStorage.getItem('mrrssChatPanelSize')!)).to.deep.equal(preferred);
+    });
   });
 });

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -246,3 +246,55 @@ describe('App', () => {
     getContextSpy.mockRestore();
   });
 });
+
+describe('AI chat panel size', () => {
+  it('restores a saved size, fits a smaller viewport, and keeps the preferred size', async () => {
+    const ChatPanel = (await import('./components/article/ArticleChatPanel.vue')).default;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => [] }))
+    );
+    vi.stubGlobal('innerWidth', 1000);
+    vi.stubGlobal('innerHeight', 800);
+    localStorage.setItem('mrrssChatPanelSize', JSON.stringify({ width: 650, height: 680 }));
+    const wrapper = mount(ChatPanel, {
+      props: {
+        article: { id: 1, title: 'Article', url: 'https://example.com' } as any,
+        articleContent: 'Article body',
+        settings: { ai_chat_enabled: true, ai_chat_profile_id: '', ai_chat_quick_prompts: '' },
+      },
+      global: {
+        plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })],
+        stubs: { Teleport: true },
+      },
+    });
+    try {
+      await nextTick();
+      const panel = wrapper.get('.chat-panel').element as HTMLElement;
+      expect(panel.style.width).toBe('650px');
+      expect(panel.style.height).toBe('680px');
+      vi.stubGlobal('innerWidth', 500);
+      vi.stubGlobal('innerHeight', 400);
+      window.dispatchEvent(new Event('resize'));
+      expect(panel.style.width).toBe('468px');
+      expect(panel.style.height).toBe('344px');
+      vi.stubGlobal('innerWidth', 1000);
+      vi.stubGlobal('innerHeight', 800);
+      window.dispatchEvent(new Event('resize'));
+      expect(panel.style.width).toBe('650px');
+      expect(JSON.parse(localStorage.getItem('mrrssChatPanelSize')!).width).toBe(650);
+      vi.spyOn(panel, 'getBoundingClientRect').mockReturnValue({ width: 650, height: 680 } as DOMRect);
+      await wrapper.get('.cursor-nw-resize').trigger('mousedown', { clientX: 100, clientY: 100 });
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 50, clientY: 60 }));
+      document.dispatchEvent(new MouseEvent('mouseup'));
+      expect(JSON.parse(localStorage.getItem('mrrssChatPanelSize')!)).toEqual({
+        width: 700,
+        height: 720,
+      });
+    } finally {
+      wrapper.unmount();
+      localStorage.removeItem('mrrssChatPanelSize');
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/frontend/src/components/article/ArticleChatPanel.vue
+++ b/frontend/src/components/article/ArticleChatPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 /* eslint-disable vue/no-v-html */
-import { ref, nextTick, computed, onMounted } from 'vue';
+import { ref, nextTick, computed, onMounted, onBeforeUnmount } from 'vue';
 import { useI18n } from 'vue-i18n';
 import {
   PhChatCircleText,
@@ -93,7 +93,9 @@ const questionPrompts = computed(() => [
 const customPrompts = computed<string[]>(() => {
   try {
     const parsed = JSON.parse(props.settings.ai_chat_quick_prompts || '[]');
-    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === 'string')
+      : [];
   } catch {
     return [];
   }
@@ -106,6 +108,42 @@ const startY = ref(0);
 const startWidth = ref(0);
 const startHeight = ref(0);
 const panelElement = ref<HTMLElement | null>(null);
+const panelSizeStorageKey = 'mrrssChatPanelSize';
+let preferredPanelSize = { width: 500, height: 600 };
+
+function applyPanelSize() {
+  const panel = panelElement.value;
+  if (!panel) return;
+  const desktop = window.innerWidth >= 768;
+  const availableWidth = Math.max(1, window.innerWidth - (desktop ? 24 : 16) - 16);
+  const availableHeight = Math.max(1, window.innerHeight - (desktop ? 56 : 40) - 16);
+  panel.style.width = `${Math.min(preferredPanelSize.width, availableWidth)}px`;
+  panel.style.height = `${Math.min(preferredPanelSize.height, availableHeight)}px`;
+}
+
+onMounted(() => {
+  try {
+    const saved = JSON.parse(localStorage.getItem(panelSizeStorageKey) || 'null');
+    if (
+      saved &&
+      Number.isFinite(saved.width) &&
+      Number.isFinite(saved.height) &&
+      saved.width >= 300 &&
+      saved.height >= 200
+    ) {
+      preferredPanelSize = { width: saved.width, height: saved.height };
+    }
+  } catch {
+    // Invalid or unavailable local storage should not prevent opening chat.
+  }
+  applyPanelSize();
+  window.addEventListener('resize', applyPanelSize);
+});
+
+onBeforeUnmount(() => {
+  stopResize();
+  window.removeEventListener('resize', applyPanelSize);
+});
 
 // Initialize: load sessions for this article
 onMounted(async () => {
@@ -263,15 +301,19 @@ function resize(e: MouseEvent) {
 
   const panel = panelElement.value;
   if (panel) {
-    panel.classList.remove('w-[500px]', 'h-[600px]', 'w-[calc(100%-2rem)]', 'md:w-96');
-    panel.style.width = `${newWidth}px`;
-    panel.style.height = `${newHeight}px`;
-    panel.style.maxWidth = 'none';
-    panel.style.maxHeight = 'none';
+    preferredPanelSize = { width: newWidth, height: newHeight };
+    applyPanelSize();
   }
 }
 
 function stopResize() {
+  if (isResizing.value) {
+    try {
+      localStorage.setItem(panelSizeStorageKey, JSON.stringify(preferredPanelSize));
+    } catch {
+      // Resizing remains available when local storage cannot be written.
+    }
+  }
   isResizing.value = false;
   document.removeEventListener('mousemove', resize);
   document.removeEventListener('mouseup', stopResize);
@@ -535,10 +577,7 @@ const currentSessionTitle = computed(() => {
 
         <!-- Messages -->
         <div ref="chatContainer" class="flex-1 overflow-y-auto p-3 space-y-3 scroll-smooth">
-          <div
-            v-if="messages.length === 0"
-            class="space-y-4 py-2 text-sm"
-          >
+          <div v-if="messages.length === 0" class="space-y-4 py-2 text-sm">
             <p class="text-center text-text-secondary">{{ t('article.chat.aiChatWelcome') }}</p>
 
             <section class="space-y-2">
@@ -598,13 +637,14 @@ const currentSessionTitle = computed(() => {
             class="flex group"
             :class="msg.role === 'user' ? 'justify-end' : 'justify-start'"
           >
-            <div class="flex items-start gap-1" :class="msg.role === 'user' ? 'flex-row-reverse' : ''">
+            <div
+              class="flex items-start gap-1"
+              :class="msg.role === 'user' ? 'flex-row-reverse' : ''"
+            >
               <div
                 class="max-w-[80%] rounded-lg px-3 py-2 text-sm select-text cursor-text"
                 :class="
-                  msg.role === 'user'
-                    ? 'bg-accent text-white'
-                    : 'bg-bg-secondary text-text-primary'
+                  msg.role === 'user' ? 'bg-accent text-white' : 'bg-bg-secondary text-text-primary'
                 "
               >
                 <!-- Thinking section -->


### PR DESCRIPTION
关闭再打开 AI 聊天后，现在会恢复用户上次拖动设置的宽度和高度。窗口变小时将面板限制在可用空间内，同时保留原偏好，窗口变大后恢复；损坏或不可用的本地存储不会阻止打开面板。

Closes #1100

验证：ESLint 通过（仅既有格式警告）；单元测试 14 文件、120 项通过；定向尺寸恢复、窗口缩放、拖动保存测试通过；前端构建与 macOS Wails 构建通过；git diff --check 通过。Node 26 的测试使用 NODE_OPTIONS=--no-experimental-webstorage 以启用 jsdom 的 localStorage。

本 PR 保留现有最小尺寸，最小宽度调整由 #1101 单独处理。

浏览器尺寸回归：拖动实际 500×600 → 620×700，仅 mouseup 保存；关闭重开和整页重载恢复 620×700。保存 680×720 后缩至 390×500 视口，面板临时为 358×444，关闭重开仍适配窄视口且保存值不变，回宽恢复 680×720。reading-interactions 共 8 项通过。
