### PR TITLE
fix：限制聊天面板最小宽度并保护标题操作布局

### DIFF
--- a/frontend/cypress/e2e/reading-interactions.cy.ts
+++ b/frontend/cypress/e2e/reading-interactions.cy.ts
@@ -188,4 +188,107 @@ describe('Reading interactions', () => {
     cy.get('[role="dialog"][aria-modal="true"]').should('be.visible');
     cy.get('@openBrowser.all').should('have.length', 0);
   });
+
+  it('uses a 500 by 600 chat default and a viewport-limited 420 by 200 drag minimum', () => {
+    cy.viewport(1280, 900);
+    setup({ ai_chat_enabled: 'true' });
+    cy.intercept('GET', '/api/ai/profiles', []);
+    cy.intercept('GET', '/api/ai/chat/sessions*', []);
+    openArticle();
+    cy.get('.js-article-chat-button').click();
+    cy.get('.chat-panel')
+      .should(($panel) => {
+        const rect = $panel[0].getBoundingClientRect();
+        expect(rect.width).to.equal(500);
+        expect(rect.height).to.equal(600);
+      })
+      .then(($panel) => {
+        const rect = $panel[0].getBoundingClientRect();
+        cy.get('.chat-panel .cursor-nw-resize').trigger('mousedown', {
+          clientX: rect.left + 2,
+          clientY: rect.top + 2,
+          button: 0,
+          force: true,
+        });
+        cy.document().trigger('mousemove', { clientX: rect.right, clientY: rect.bottom });
+        cy.document().trigger('mouseup');
+      });
+    cy.get('.chat-panel').should(($panel) => {
+      const rect = $panel[0].getBoundingClientRect();
+      expect(rect.width).to.equal(420);
+      expect(rect.height).to.equal(200);
+    });
+    cy.viewport(320, 230);
+    cy.get('.chat-panel').should(($panel) => {
+      const rect = $panel[0].getBoundingClientRect();
+      expect(rect.width).to.equal(288);
+      expect(rect.height).to.equal(174);
+      expect(rect.left).to.be.at.least(0);
+      expect(rect.top).to.be.at.least(0);
+      expect(rect.right).to.be.at.most(320);
+      expect(rect.bottom).to.be.at.most(230);
+    });
+    cy.viewport(1280, 900);
+    cy.get('.chat-panel').should(($panel) => {
+      const rect = $panel[0].getBoundingClientRect();
+      expect(rect.width).to.equal(420);
+      expect(rect.height).to.equal(200);
+    });
+  });
+
+  it('truncates long session titles without pushing header actions outside the chat panel', () => {
+    cy.viewport(1280, 900);
+    setup({ ai_chat_enabled: 'true' });
+    const title = 'Long chat session title '.repeat(30);
+    cy.intercept('GET', '/api/ai/profiles', [
+      { id: 1, name: 'Long AI profile name '.repeat(10), is_default: true },
+    ]);
+    cy.intercept('GET', '/api/ai/chat/sessions*', [{ id: 1, article_id: article.id, title }]);
+    cy.intercept('GET', '/api/ai/chat/messages*', []).as('chatMessages');
+    openArticle();
+    cy.get('.js-article-chat-button').click();
+    cy.wait('@chatMessages');
+    cy.get('.chat-panel').then(($panel) => {
+      const rect = $panel[0].getBoundingClientRect();
+      cy.get('.chat-panel .cursor-nw-resize').trigger('mousedown', {
+        clientX: rect.left + 2,
+        clientY: rect.top + 2,
+        button: 0,
+        force: true,
+      });
+      cy.document().trigger('mousemove', { clientX: rect.right, clientY: rect.bottom });
+      cy.document().trigger('mouseup');
+    });
+    for (const [viewportWidth, viewportHeight, expectedWidth] of [
+      [1280, 900, 420],
+      [320, 330, 288],
+    ]) {
+      cy.viewport(viewportWidth, viewportHeight);
+      cy.get('.chat-panel').should(($panel) => {
+        const panel = $panel[0];
+        const rect = panel.getBoundingClientRect();
+        expect(rect.width).to.equal(expectedWidth);
+        const header = panel.firstElementChild as HTMLElement;
+        expect(header.scrollWidth).to.be.at.most(header.clientWidth);
+        for (const button of header.querySelectorAll('button')) {
+          const bounds = button.getBoundingClientRect();
+          expect(bounds.width).to.be.greaterThan(0);
+          expect(bounds.left).to.be.at.least(rect.left);
+          expect(bounds.right).to.be.at.most(rect.right);
+          expect(bounds.top).to.be.at.least(rect.top);
+          expect(bounds.bottom).to.be.at.most(rect.bottom);
+        }
+      });
+      cy.get('[data-testid="chat-session-switcher"] span')
+        .should('have.text', title)
+        .should(($title) => {
+          expect($title[0].scrollWidth).to.be.greaterThan($title[0].clientWidth);
+          expect(getComputedStyle($title[0]).textOverflow).to.equal('ellipsis');
+        });
+      cy.get('.chat-panel button[title="Close"]').should('be.visible');
+      cy.get('[data-testid="chat-new-session"]').should('be.visible');
+    }
+    cy.get('.chat-panel button[title="Close"]').click();
+    cy.get('.chat-panel').should('not.exist');
+  });
 });

--- a/frontend/src/components/article/ArticleChatPanel.vue
+++ b/frontend/src/components/article/ArticleChatPanel.vue
@@ -258,7 +258,7 @@ function resize(e: MouseEvent) {
   const deltaX = startX.value - e.clientX;
   const deltaY = startY.value - e.clientY;
 
-  const newWidth = Math.max(300, startWidth.value + deltaX);
+  const newWidth = Math.max(420, startWidth.value + deltaX);
   const newHeight = Math.max(200, startHeight.value + deltaY);
 
   const panel = panelElement.value;
@@ -266,8 +266,6 @@ function resize(e: MouseEvent) {
     panel.classList.remove('w-[500px]', 'h-[600px]', 'w-[calc(100%-2rem)]', 'md:w-96');
     panel.style.width = `${newWidth}px`;
     panel.style.height = `${newHeight}px`;
-    panel.style.maxWidth = 'none';
-    panel.style.maxHeight = 'none';
   }
 }
 
@@ -415,20 +413,20 @@ const currentSessionTitle = computed(() => {
         <div
           class="flex items-center justify-between p-3 border-b border-border bg-bg-secondary rounded-t-xl relative"
         >
-          <div class="flex items-center gap-2 flex-1">
-            <PhChatCircleText :size="20" class="text-accent" />
+          <div class="flex min-w-0 items-center gap-2 flex-1">
+            <PhChatCircleText :size="20" class="shrink-0 text-accent" />
             <button
-              class="flex items-center gap-1 text-sm font-medium hover:text-accent transition-colors"
+              class="flex min-w-0 items-center gap-1 text-sm font-medium hover:text-accent transition-colors"
               :disabled="isLoading"
               :title="t('article.chat.switchSession')"
               data-testid="chat-session-switcher"
               @click.stop="showSessions = !showSessions"
             >
-              <span>{{ currentSessionTitle }}</span>
-              <PhClockCounterClockwise :size="16" />
+              <span class="truncate">{{ currentSessionTitle }}</span>
+              <PhClockCounterClockwise :size="16" class="shrink-0" />
             </button>
           </div>
-          <div class="flex items-center gap-1">
+          <div class="flex shrink-0 items-center gap-1">
             <BaseSelect
               v-if="profileOptions.length > 0"
               v-model="selectedProfileId"
@@ -669,10 +667,21 @@ const currentSessionTitle = computed(() => {
 
 <style>
 .chat-panel {
+  min-width: min(420px, calc(100vw - 2rem));
+  max-width: calc(100vw - 2rem);
+  max-height: calc(100vh - 3.5rem);
   user-select: text !important;
   -webkit-user-select: text !important;
   -moz-user-select: text !important;
   -ms-user-select: text !important;
+}
+
+@media (min-width: 768px) {
+  .chat-panel {
+    min-width: min(420px, calc(100vw - 2.5rem));
+    max-width: calc(100vw - 2.5rem);
+    max-height: calc(100vh - 4.5rem);
+  }
 }
 
 .chat-panel.select-none {


### PR DESCRIPTION
缩小 AI 聊天面板时，标题保持单行省略，右侧模型、设置、新建和关闭操作保持可见。拖动最小宽度调整为 420px；在更窄的窗口中，面板宽高仍受可用视口约束。

Closes #1101

验证：ESLint 通过（仅既有格式警告）；14 个文件、119 项单元测试通过；前端构建、macOS Wails 构建、git diff --check 通过。纯布局调整没有新增测试文件。

浏览器尺寸回归：默认实际 500×600，向内拖动限制为 420×200；320×230 视口中临时收敛为 288×174，回宽恢复 420×200。使用超长会话名与模型配置名，在 420px 和窄屏 288px 面板中验证标题省略、所有标题栏按钮矩形均位于面板内、无水平溢出且关闭可用。reading-interactions 共 8 项通过。
