### PR TITLE
fix：根据首问自动命名默认聊天会话

### DIFF
--- a/internal/database/article_db_test.go
+++ b/internal/database/article_db_test.go
@@ -888,3 +888,74 @@ func TestSaveArticlesValidPubDateStillUpdatesTime(t *testing.T) {
 		t.Fatalf("valid pubDate not honored on refresh: got %v, want %v (diff %v)", stored, t2, diff)
 	}
 }
+
+func TestFirstChatQuestionNamesOnlyEmptyDefaultSessions(t *testing.T) {
+	db := setupDBWithFeed(t)
+	var feedID int64
+	if err := db.QueryRow(`SELECT id FROM feeds LIMIT 1`).Scan(&feedID); err != nil {
+		t.Fatal(err)
+	}
+	result, err := db.Exec(`INSERT INTO articles(feed_id,title,url) VALUES(?, 'chat', 'https://example.com/chat-title')`, feedID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	articleID, _ := result.LastInsertId()
+	for _, original := range []string{"New Chat", "新对话", "My own title"} {
+		t.Run(original, func(t *testing.T) {
+			id, err := db.CreateChatSession(articleID, original)
+			if err != nil {
+				t.Fatal(err)
+			}
+			question := strings.Repeat("问😀", 40)
+			if _, err := db.CreateChatMessage(id, "user", "  "+question+"  ", ""); err != nil {
+				t.Fatal(err)
+			}
+			session, err := db.GetChatSession(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := string([]rune(question)[:60])
+			if original == "My own title" {
+				want = original
+			}
+			if session.Title != want {
+				t.Fatalf("title=%q want=%q", session.Title, want)
+			}
+			if _, err := db.CreateChatMessage(id, "user", "second question", ""); err != nil {
+				t.Fatal(err)
+			}
+			session, _ = db.GetChatSession(id)
+			if session.Title != want {
+				t.Fatal("later question replaced title")
+			}
+		})
+	}
+	populatedID, err := db.CreateChatSession(articleID, "New Chat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.CreateChatMessage(populatedID, "assistant", "existing answer", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.CreateChatMessage(populatedID, "user", "later question", ""); err != nil {
+		t.Fatal(err)
+	}
+	populated, err := db.GetChatSession(populatedID)
+	if err != nil || populated.Title != "New Chat" {
+		t.Fatalf("populated default session was renamed: %+v %v", populated, err)
+	}
+	id, err := db.CreateChatSession(articleID, "New Chat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TRIGGER reject_chat_message BEFORE INSERT ON chat_messages BEGIN SELECT RAISE(ABORT, 'test failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.CreateChatMessage(id, "user", "must roll back title", ""); err == nil {
+		t.Fatal("expected insert failure")
+	}
+	session, err := db.GetChatSession(id)
+	if err != nil || session.Title != "New Chat" || session.MessageCount != 0 {
+		t.Fatalf("transaction did not roll back: %+v %v", session, err)
+	}
+}

--- a/internal/database/chat_db.go
+++ b/internal/database/chat_db.go
@@ -3,6 +3,7 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -129,18 +130,44 @@ func (db *DB) DeleteChatSession(sessionID int64) error {
 
 // CreateChatMessage creates a new chat message in a session
 func (db *DB) CreateChatMessage(sessionID int64, role, content, thinking string) (int64, error) {
-	result, err := db.Exec(
+	tx, err := db.Begin()
+	if err != nil {
+		return 0, fmt.Errorf("begin chat message: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Name legacy empty sessions from their first question without replacing
+	// custom titles or racing another message or a manual rename.
+	if role == "user" && strings.TrimSpace(content) != "" {
+		title := []rune(strings.TrimSpace(content))
+		if len(title) > 60 {
+			title = title[:60]
+		}
+		if _, err := tx.Exec(`UPDATE chat_sessions SET title = ?
+			WHERE id = ? AND title IN ('New Chat', '新对话')
+			AND NOT EXISTS (SELECT 1 FROM chat_messages WHERE session_id = ?)`,
+			string(title), sessionID, sessionID); err != nil {
+			return 0, fmt.Errorf("name first chat message: %w", err)
+		}
+	}
+	result, err := tx.Exec(
 		`INSERT INTO chat_messages (session_id, role, content, thinking, created_at) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)`,
 		sessionID, role, content, thinking,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create chat message: %w", err)
 	}
-
-	// Update session timestamp
-	_ = db.UpdateChatSessionTimestamp(sessionID)
-
-	return result.LastInsertId()
+	if _, err := tx.Exec(`UPDATE chat_sessions SET updated_at = CURRENT_TIMESTAMP WHERE id = ?`, sessionID); err != nil {
+		return 0, fmt.Errorf("update chat session timestamp: %w", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("read chat message ID: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit chat message: %w", err)
+	}
+	return id, nil
 }
 
 // GetChatMessages retrieves all messages for a session, ordered by created_at asc


### PR DESCRIPTION
A newly created conversation kept its default title after its first question, making the history difficult to identify. Name an empty `New Chat` or `新对话` session from the first user question, trimmed to 60 Unicode characters.

The conditional title change and message insertion share a transaction. Existing conversations and custom titles remain intact; a failed message insertion rolls back the title.

Validation: `go vet ./...`, `go test -timeout=5m ./...`, ESLint, all 119 frontend unit tests, frontend production build, `wails3 build`, and `git diff --check`. Extended the existing database test file for Unicode truncation, English/Chinese defaults, custom/populated titles, later messages, and rollback. Frontend tests used `NODE_OPTIONS=--no-experimental-webstorage` for the local Node 26 runtime.

Closes #1102.
