### PR TITLE
fix：避免聊天模型选择区域误选文字

### DIFF
--- a/frontend/cypress/e2e/reading-interactions.cy.ts
+++ b/frontend/cypress/e2e/reading-interactions.cy.ts
@@ -89,6 +89,8 @@ describe('Reading interactions', () => {
     }).as('modelChat');
     openArticle();
     cy.get('button[title="AI Chat"]').click();
+    cy.get('.chat-profile-selector .select-trigger .select-text')
+      .should('have.css', 'user-select', 'none');
     cy.get('.chat-profile-selector .select-trigger')
       .should('have.css', 'user-select', 'none')
       .click();

--- a/frontend/cypress/e2e/reading-interactions.cy.ts
+++ b/frontend/cypress/e2e/reading-interactions.cy.ts
@@ -76,6 +76,33 @@ function openArticle() {
 }
 
 describe('Reading interactions', () => {
+  it('prevents selecting model labels while keeping model changes and message selection available', () => {
+    setup({ ai_chat_enabled: 'true', translation_enabled: 'false' });
+    cy.intercept('GET', '/api/ai/profiles', [
+      { id: 1, name: 'Model One', is_default: true },
+      { id: 2, name: 'Model Two', is_default: false },
+    ]);
+    cy.intercept('GET', '/api/ai/chat/sessions*', []);
+    cy.intercept('POST', '/api/ai-chat', (req) => {
+      expect(req.body.profile_id).to.equal(2);
+      req.reply({ response: 'Selectable answer', session_id: 1 });
+    }).as('modelChat');
+    openArticle();
+    cy.get('button[title="AI Chat"]').click();
+    cy.get('.chat-profile-selector .select-trigger')
+      .should('have.css', 'user-select', 'none')
+      .click();
+    cy.contains('.chat-profile-selector .select-option', 'Model Two')
+      .should('have.css', 'user-select', 'none')
+      .click();
+    cy.get('.chat-profile-selector .select-trigger').should('contain', 'Model Two');
+    cy.get('input[placeholder="Type a message..."]').type('Question{enter}');
+    cy.wait('@modelChat');
+    cy.contains('.chat-panel .select-text', 'Selectable answer')
+      .should('be.visible')
+      .and('have.css', 'user-select', 'text');
+  });
+
   it('translates only the requested title or paragraph in manual mode, and retries failures', () => {
     let calls = 0;
     let paragraphCalls = 0;

--- a/frontend/src/components/article/ArticleChatPanel.vue
+++ b/frontend/src/components/article/ArticleChatPanel.vue
@@ -676,12 +676,6 @@ const currentSessionTitle = computed(() => {
   -ms-user-select: text !important;
 }
 
-.chat-panel .chat-profile-selector,
-.chat-panel .chat-profile-selector * {
-  user-select: none !important;
-  -webkit-user-select: none !important;
-}
-
 .chat-panel.select-none {
   user-select: none !important;
   -webkit-user-select: none !important;
@@ -702,6 +696,12 @@ const currentSessionTitle = computed(() => {
   -webkit-user-select: text !important;
   -moz-user-select: text !important;
   -ms-user-select: text !important;
+}
+
+.chat-panel .chat-profile-selector,
+.chat-panel .chat-profile-selector * {
+  user-select: none !important;
+  -webkit-user-select: none !important;
 }
 
 .chat-panel-enter-active,

--- a/frontend/src/components/article/ArticleChatPanel.vue
+++ b/frontend/src/components/article/ArticleChatPanel.vue
@@ -676,8 +676,8 @@ const currentSessionTitle = computed(() => {
   -ms-user-select: text !important;
 }
 
-.chat-panel :deep(.chat-profile-selector),
-.chat-panel :deep(.chat-profile-selector *) {
+.chat-panel .chat-profile-selector,
+.chat-panel .chat-profile-selector * {
   user-select: none !important;
   -webkit-user-select: none !important;
 }

--- a/frontend/src/components/article/ArticleChatPanel.vue
+++ b/frontend/src/components/article/ArticleChatPanel.vue
@@ -432,6 +432,7 @@ const currentSessionTitle = computed(() => {
             <BaseSelect
               v-if="profileOptions.length > 0"
               v-model="selectedProfileId"
+              class="chat-profile-selector"
               :options="profileOptions"
               width="w-28 sm:w-36"
               size="xs"
@@ -673,6 +674,12 @@ const currentSessionTitle = computed(() => {
   -webkit-user-select: text !important;
   -moz-user-select: text !important;
   -ms-user-select: text !important;
+}
+
+.chat-panel :deep(.chat-profile-selector),
+.chat-panel :deep(.chat-profile-selector *) {
+  user-select: none !important;
+  -webkit-user-select: none !important;
 }
 
 .chat-panel.select-none {


### PR DESCRIPTION
AI 聊天的模型选择控件与选项现在禁止选中文字，避免点击或拖动时误选。样式只作用于聊天中的模型选择实例，消息正文仍可选择和复制，模型切换行为保持可用。

Closes #1103

验证：ESLint、14 文件 119 项单元测试、前端构建、macOS Wails 构建和 git diff --check 均通过。Electron/Cypress 的 reading-interactions 7 项通过：实际计算样式确认触发按钮、按钮内 .select-text 标签与当前下拉选项 user-select=none、模型可切换、正文 user-select=text。复用了已有测试文件，没有修改共享选择器行为。
