### PR TITLE
fix：隔离聊天历史标题编辑与消息操作

### DIFF
--- a/frontend/cypress/e2e/reading-interactions.cy.ts
+++ b/frontend/cypress/e2e/reading-interactions.cy.ts
@@ -76,6 +76,34 @@ function openArticle() {
 }
 
 describe('Reading interactions', () => {
+  it('keeps title editing above message actions without selecting the session on save', () => {
+    setup({ ai_chat_enabled: 'true', translation_enabled: 'false' });
+    cy.intercept('GET', '/api/ai/profiles', []);
+    cy.intercept('GET', '/api/ai/chat/sessions*', [
+      { id: 1, article_id: 1, title: 'Saved session', message_count: 1 },
+    ]);
+    cy.intercept('GET', '/api/ai/chat/messages*', [
+      { id: 1, role: 'user', content: 'Previous question', created_at: '' },
+    ]).as('chatMessages');
+    cy.intercept('PUT', '/api/ai/chat/session*', (req) => {
+      expect(req.body.title).to.equal('Renamed session');
+      req.reply({ success: true });
+    }).as('renameChat');
+    openArticle();
+    cy.get('button[title="AI Chat"]').click();
+    cy.wait('@chatMessages');
+    cy.get('[data-testid="chat-session-switcher"]').click();
+    cy.get('[data-session-id="1"] button').first().click();
+    cy.get('[data-session-id="1"] input').clear().type('Renamed session');
+    cy.get('.chat-panel button[title="Copy message"]').should('not.be.visible');
+    cy.get('[data-session-id="1"] button').first().click();
+    cy.wait('@renameChat');
+    cy.get('[data-session-id="1"]').should('be.visible').and('contain', 'Renamed session');
+    cy.get('@chatMessages.all').should('have.length', 1);
+    cy.get('[data-testid="chat-session-switcher"]').click();
+    cy.contains('.chat-panel', 'Previous question').should('be.visible');
+  });
+
   it('translates only the requested title or paragraph in manual mode, and retries failures', () => {
     let calls = 0;
     let paragraphCalls = 0;

--- a/frontend/src/components/article/ArticleChatPanel.vue
+++ b/frontend/src/components/article/ArticleChatPanel.vue
@@ -477,7 +477,7 @@ const currentSessionTitle = computed(() => {
         <Transition name="slide-in">
           <div
             v-if="showSessions"
-            class="absolute top-12 left-0 right-0 bottom-12 bg-bg-secondary border-b border-border rounded-b-xl overflow-y-auto scroll-smooth"
+            class="absolute top-12 left-0 right-0 bottom-12 z-10 bg-bg-secondary border-b border-border rounded-b-xl overflow-y-auto scroll-smooth"
           >
             <div class="p-2 space-y-1">
               <div
@@ -492,17 +492,17 @@ const currentSessionTitle = computed(() => {
                 @click.stop="selectSession(session.id)"
               >
                 <PhChatCircleText :size="16" class="text-text-secondary" />
-                <div v-if="editingSessionId === session.id" class="flex-1 flex items-center gap-1">
+                <div v-if="editingSessionId === session.id" class="flex-1 min-w-0 flex items-center gap-1">
                   <input
                     v-model="editingSessionTitle"
-                    class="flex-1 px-2 py-1 text-sm bg-bg-primary border border-border rounded focus:outline-none focus:border-accent"
+                    class="flex-1 min-w-0 px-2 py-1 text-sm bg-bg-primary border border-border rounded focus:outline-none focus:border-accent"
                     @keyup.enter="saveSessionTitle(session.id)"
                     @keyup.esc="cancelEditSession"
                     @click.stop
                   />
                   <button
                     class="p-1 hover:bg-bg-primary rounded"
-                    @click="saveSessionTitle(session.id)"
+                    @click.stop="saveSessionTitle(session.id)"
                   >
                     <PhPaperPlaneRight :size="14" />
                   </button>
@@ -534,7 +534,11 @@ const currentSessionTitle = computed(() => {
         </Transition>
 
         <!-- Messages -->
-        <div ref="chatContainer" class="flex-1 overflow-y-auto p-3 space-y-3 scroll-smooth">
+        <div
+          ref="chatContainer"
+          class="flex-1 overflow-y-auto p-3 space-y-3 scroll-smooth"
+          :class="{ invisible: showSessions }"
+        >
           <div
             v-if="messages.length === 0"
             class="space-y-4 py-2 text-sm"


### PR DESCRIPTION
打开聊天历史列表时，消息区域暂时不可见但保留位置，使标题编辑不会与消息复制按钮重叠。列表提升层级，编辑输入可收缩；点击保存只保存标题，不再冒泡触发选择会话。

Closes #1105

验证：Electron/Cypress 7 项通过，验证编辑期间复制操作不可见、保存后历史列表仍显示且不重复加载会话、关闭列表后消息恢复。ESLint、14 文件 119 项单元测试、前端构建、macOS Wails 构建、git diff --check 通过。
