### PR TITLE
fix：清理聊天历史标题编辑状态

### DIFF
--- a/frontend/cypress/e2e/reading-interactions.cy.ts
+++ b/frontend/cypress/e2e/reading-interactions.cy.ts
@@ -76,6 +76,36 @@ function openArticle() {
 }
 
 describe('Reading interactions', () => {
+  it('discards unsaved title edits when leaving the session list or selecting another session', () => {
+    setup({ ai_chat_enabled: 'true', translation_enabled: 'false' });
+    cy.intercept('GET', '/api/ai/profiles', []);
+    cy.intercept('GET', '/api/ai/chat/sessions*', [
+      { id: 1, article_id: 1, title: 'First session', message_count: 0 },
+      { id: 2, article_id: 1, title: 'Second session', message_count: 0 },
+    ]);
+    cy.intercept('GET', '/api/ai/chat/messages*', []).as('chatMessages');
+    cy.intercept('PUT', '/api/ai/chat/session*', () => {
+      throw new Error('Leaving an edit must not save the draft');
+    });
+    openArticle();
+    cy.get('button[title="AI Chat"]').click();
+    cy.wait('@chatMessages');
+    cy.get('[data-testid="chat-session-switcher"]').click();
+    cy.get('[data-session-id="1"] button').first().click();
+    cy.get('[data-session-id="1"] input').clear().type('Unsaved title');
+    cy.get('[data-testid="chat-session-switcher"]').click();
+    cy.get('[data-testid="chat-session-switcher"]').click();
+    cy.get('[data-session-id="1"] input').should('not.exist');
+    cy.get('[data-session-id="1"]').should('contain', 'First session');
+    cy.get('[data-session-id="1"] button').first().click();
+    cy.get('[data-session-id="1"] input').clear().type('Another unsaved title');
+    cy.get('[data-session-id="2"]').click();
+    cy.wait('@chatMessages');
+    cy.get('[data-testid="chat-session-switcher"]').click();
+    cy.get('[data-session-id="1"] input').should('not.exist');
+    cy.get('[data-session-id="1"]').should('contain', 'First session');
+  });
+
   it('translates only the requested title or paragraph in manual mode, and retries failures', () => {
     let calls = 0;
     let paragraphCalls = 0;

--- a/frontend/cypress/e2e/reading-interactions.cy.ts
+++ b/frontend/cypress/e2e/reading-interactions.cy.ts
@@ -76,6 +76,36 @@ function openArticle() {
 }
 
 describe('Reading interactions', () => {
+  it('keeps a failed title edit available for retry and shows the failure', () => {
+    let saves = 0;
+    setup({ ai_chat_enabled: 'true', translation_enabled: 'false' });
+    cy.intercept('GET', '/api/ai/profiles', []);
+    cy.intercept('GET', '/api/ai/chat/sessions*', [
+      { id: 1, article_id: 1, title: 'Original title', message_count: 0 },
+    ]);
+    cy.intercept('GET', '/api/ai/chat/messages*', []).as('chatMessages');
+    cy.intercept('PUT', '/api/ai/chat/session*', (req) => {
+      expect(req.body.title).to.equal('Title to retry');
+      saves++;
+      req.reply(saves === 1 ? { statusCode: 500, body: {} } : { success: true });
+    }).as('saveTitle');
+    openArticle();
+    cy.get('button[title="AI Chat"]').click();
+    cy.wait('@chatMessages');
+    cy.get('[data-testid="chat-session-switcher"]').click();
+    cy.get('[data-session-id="1"] button').first().click();
+    cy.get('[data-session-id="1"] input').clear().type('Title to retry');
+    cy.get('[data-session-id="1"] button').first().click();
+    cy.wait('@saveTitle');
+    cy.contains('Failed to save conversation title. Please try again.').should('be.visible');
+    cy.get('[data-session-id="1"] input').should('be.visible').and('have.value', 'Title to retry');
+    cy.get('[data-testid="chat-session-switcher"]').should('contain', 'Original title');
+    cy.get('[data-session-id="1"] button').first().click();
+    cy.wait('@saveTitle');
+    cy.get('[data-session-id="1"] input').should('not.exist');
+    cy.get('[data-session-id="1"]').should('contain', 'Title to retry');
+  });
+
   it('discards unsaved title edits when leaving the session list or selecting another session', () => {
     setup({ ai_chat_enabled: 'true', translation_enabled: 'false' });
     cy.intercept('GET', '/api/ai/profiles', []);

--- a/frontend/src/components/article/ArticleChatPanel.vue
+++ b/frontend/src/components/article/ArticleChatPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 /* eslint-disable vue/no-v-html */
-import { ref, nextTick, computed, onMounted } from 'vue';
+import { ref, nextTick, computed, onMounted, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import {
   PhChatCircleText,
@@ -69,6 +69,8 @@ const showSessions = ref(false);
 const editingSessionId = ref<number | null>(null);
 const editingSessionTitle = ref('');
 const selectedProfileId = ref(props.settings.ai_chat_profile_id || '');
+
+watch([showSessions, currentSessionId, () => props.article.id], cancelEditSession);
 
 const profileOptions = computed(() =>
   profiles.value.map((profile) => ({ value: String(profile.id), label: profile.name }))
@@ -212,18 +214,23 @@ function startEditSession(session: ChatSession, e: Event) {
 }
 
 async function saveSessionTitle(sessionId: number) {
+  if (editingSessionId.value !== sessionId) return;
+  const title = editingSessionTitle.value;
   try {
-    await fetch(`/api/ai/chat/session?session_id=${sessionId}`, {
+    const response = await fetch(`/api/ai/chat/session?session_id=${sessionId}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title: editingSessionTitle.value }),
+      body: JSON.stringify({ title }),
     });
 
+    if (!response.ok) throw new Error(`Failed to update session title: ${response.status}`);
     const session = sessions.value.find((s) => s.id === sessionId);
     if (session) {
-      session.title = editingSessionTitle.value;
+      session.title = title;
     }
-    editingSessionId.value = null;
+    if (editingSessionId.value === sessionId && editingSessionTitle.value === title) {
+      cancelEditSession();
+    }
   } catch (e) {
     console.error('Failed to update session title:', e);
   }

--- a/frontend/src/components/article/ArticleChatPanel.vue
+++ b/frontend/src/components/article/ArticleChatPanel.vue
@@ -233,6 +233,7 @@ async function saveSessionTitle(sessionId: number) {
     }
   } catch (e) {
     console.error('Failed to update session title:', e);
+    window.showToast(t('article.chat.titleSaveFailed'), 'error');
   }
 }
 
@@ -509,7 +510,7 @@ const currentSessionTitle = computed(() => {
                   />
                   <button
                     class="p-1 hover:bg-bg-primary rounded"
-                    @click="saveSessionTitle(session.id)"
+                    @click.stop="saveSessionTitle(session.id)"
                   >
                     <PhPaperPlaneRight :size="14" />
                   </button>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -65,6 +65,7 @@ const en: TranslationMessages = {
       volume: 'Volume',
     },
     chat: {
+      titleSaveFailed: 'Failed to save conversation title. Please try again.',
       aiChat: 'AI Chat',
       aiChatError: 'Failed to get response from AI. Please try again.',
       historySaveFailed: 'The answer was generated but could not be saved to chat history.',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -62,6 +62,7 @@ const zh: TranslationMessages = {
       volume: '音量',
     },
     chat: {
+      titleSaveFailed: '保存对话标题失败，请重试。',
       aiChat: 'AI 聊天',
       aiChatError: '无法获取 AI 响应，请重试。',
       historySaveFailed: '回答已生成，但未能保存到历史记录。',


### PR DESCRIPTION
退出聊天历史列表、切换会话或切换阅读文章后，未保存的对话标题草稿会被丢弃，重新打开列表时显示已保存标题。异步保存固定使用发起请求时的标题，失败响应显示错误提示并保留草稿供重试，不会被误当成保存成功，旧请求也不会清掉后续编辑草稿。

Closes #1106

验证：Electron/Cypress 8 项通过，包括关闭再打开列表、编辑后切换其他会话及未触发保存请求，并验证 HTTP 500 保存失败保留草稿和错误提示、重试成功。ESLint、14 文件 119 项单元测试、前端构建、macOS Wails 构建、git diff --check 通过。
