### PR TITLE
style：使用勾选图标保存聊天标题

### DIFF
--- a/frontend/src/components/article/ArticleChatPanel.vue
+++ b/frontend/src/components/article/ArticleChatPanel.vue
@@ -4,6 +4,7 @@ import { ref, nextTick, computed, onMounted } from 'vue';
 import { useI18n } from 'vue-i18n';
 import {
   PhChatCircleText,
+  PhCheck,
   PhX,
   PhPaperPlaneRight,
   PhSpinner,
@@ -502,9 +503,11 @@ const currentSessionTitle = computed(() => {
                   />
                   <button
                     class="p-1 hover:bg-bg-primary rounded"
+                    :title="t('common.save')"
+                    :aria-label="t('common.save')"
                     @click="saveSessionTitle(session.id)"
                   >
-                    <PhPaperPlaneRight :size="14" />
+                    <PhCheck :size="14" />
                   </button>
                 </div>
                 <span v-else class="flex-1 text-sm truncate">{{ session.title }}</span>


### PR DESCRIPTION
编辑对话标题时，保存按钮改用勾选图标，并添加已国际化的保存提示及可访问名称。消息发送按钮继续使用发送图标。

Closes #1107

验证：ESLint、14 文件 119 项单元测试、前端构建、macOS Wails 构建、git diff --check 通过。这是局部图标和语义标签调整。
