### PR TITLE
fix：展开聊天历史时禁用输入和发送

### DIFF
--- a/frontend/cypress/e2e/reading-interactions.cy.ts
+++ b/frontend/cypress/e2e/reading-interactions.cy.ts
@@ -76,6 +76,43 @@ function openArticle() {
 }
 
 describe('Reading interactions', () => {
+  it('disables composing only while the history list is open and allows continuing a selected session', () => {
+    let sends = 0;
+    setup({ ai_chat_enabled: 'true', translation_enabled: 'false' });
+    cy.intercept('GET', '/api/ai/profiles', []);
+    cy.intercept('GET', '/api/ai/chat/sessions*', [
+      { id: 1, article_id: 1, title: 'Saved session', message_count: 1 },
+    ]);
+    cy.intercept('GET', '/api/ai/chat/messages*', [
+      { id: 1, role: 'user', content: 'Previous question', created_at: '' },
+    ]).as('chatMessages');
+    cy.intercept('POST', '/api/ai-chat', (req) => {
+      sends++;
+      expect(req.body.session_id).to.equal(1);
+      expect(req.body.messages.at(-1).content).to.equal('Continue this conversation');
+      req.reply({ response: 'Continued answer', session_id: 1 });
+    }).as('continueChat');
+    openArticle();
+    cy.get('button[title="AI Chat"]').click();
+    cy.wait('@chatMessages');
+    cy.get('input[placeholder="Type a message..."]').type('Continue this conversation');
+    cy.get('[data-testid="chat-session-switcher"]').click();
+    cy.get('input[placeholder="Type a message..."]')
+      .should('be.disabled')
+      .trigger('keydown', { key: 'Enter', force: true });
+    cy.get('input[placeholder="Type a message..."]').parent().find('button').should('be.disabled');
+    cy.then(() => expect(sends).to.equal(0));
+    cy.get('[data-session-id="1"]').click();
+    cy.wait('@chatMessages');
+    cy.get('input[placeholder="Type a message..."]')
+      .should('be.enabled')
+      .should('have.value', 'Continue this conversation')
+      .type('{enter}');
+    cy.wait('@continueChat');
+    cy.contains('.chat-panel', 'Continued answer').should('be.visible');
+    cy.then(() => expect(sends).to.equal(1));
+  });
+
   it('translates only the requested title or paragraph in manual mode, and retries failures', () => {
     let calls = 0;
     let paragraphCalls = 0;

--- a/frontend/src/components/article/ArticleChatPanel.vue
+++ b/frontend/src/components/article/ArticleChatPanel.vue
@@ -279,7 +279,7 @@ function stopResize() {
 
 async function sendMessage() {
   const message = inputMessage.value.trim();
-  if (!message || isLoading.value) return;
+  if (!message || isLoading.value || showSessions.value) return;
 
   messages.value.push({
     id: 0,
@@ -364,6 +364,7 @@ async function sendMessage() {
 }
 
 async function sendSuggestedPrompt(prompt: string) {
+  if (isLoading.value || showSessions.value) return;
   inputMessage.value = prompt;
   await sendMessage();
 }
@@ -551,6 +552,7 @@ const currentSessionTitle = computed(() => {
                   :key="prompt"
                   type="button"
                   class="cursor-pointer rounded-lg border border-border bg-bg-secondary px-3 py-2 text-left text-text-primary transition-colors hover:border-accent hover:bg-bg-tertiary"
+                  :disabled="isLoading || showSessions"
                   @click="sendSuggestedPrompt(prompt)"
                 >
                   {{ prompt }}
@@ -568,6 +570,7 @@ const currentSessionTitle = computed(() => {
                   :key="prompt"
                   type="button"
                   class="cursor-pointer rounded-lg border border-border bg-bg-secondary px-3 py-2 text-left text-text-primary transition-colors hover:border-accent hover:bg-bg-tertiary"
+                  :disabled="isLoading || showSessions"
                   @click="sendSuggestedPrompt(prompt)"
                 >
                   {{ prompt }}
@@ -585,6 +588,7 @@ const currentSessionTitle = computed(() => {
                   :key="prompt"
                   type="button"
                   class="cursor-pointer rounded-lg border border-border bg-bg-secondary px-3 py-2 text-left text-text-primary transition-colors hover:border-accent hover:bg-bg-tertiary"
+                  :disabled="isLoading || showSessions"
                   @click="sendSuggestedPrompt(prompt)"
                 >
                   {{ prompt }}
@@ -650,11 +654,11 @@ const currentSessionTitle = computed(() => {
               type="text"
               :placeholder="t('article.chat.aiChatInputPlaceholder')"
               class="flex-1 px-3 py-2 bg-bg-tertiary border border-border rounded-lg text-sm focus:outline-none focus:border-accent"
-              :disabled="isLoading"
+              :disabled="isLoading || showSessions"
               @keydown="handleKeydown"
             />
             <button
-              :disabled="isLoading || !inputMessage.trim()"
+              :disabled="isLoading || showSessions || !inputMessage.trim()"
               class="px-3 py-2 bg-accent text-white rounded-lg hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               @click="sendMessage"
             >


### PR DESCRIPTION
展开 AI 聊天历史列表期间，输入框、发送和快捷提示暂停使用，发送函数也阻止键盘等路径误发。关闭列表或选择一个历史会话后恢复输入，可以继续已有会话。

Closes #1108

验证：Electron/Cypress 7 项通过，验证列表期间输入及发送被禁用、强制 Enter 不发请求、选择历史会话后按原 session ID 继续发送。ESLint、14 文件 119 项单元测试、前端构建、macOS Wails 构建、git diff --check 通过。
