### PR TITLE
fix：首次发送才创建聊天历史会话

### DIFF
--- a/frontend/cypress/e2e/article-operations.cy.ts
+++ b/frontend/cypress/e2e/article-operations.cy.ts
@@ -372,6 +372,7 @@ describe('Article Operations', () => {
       body: { content: '<p>Article context for AI chat</p>', cached: true },
     }).as('chatArticleContent');
     cy.intercept('POST', '/api/articles/read*', { statusCode: 200, body: { success: true } });
+    cy.intercept('GET', '/api/ai/profiles', { statusCode: 200, body: [] });
     cy.intercept('GET', '/api/ai/chat/sessions*', (req) => {
       req.reply({ statusCode: 200, body: sessions });
     }).as('chatSessions');
@@ -453,8 +454,7 @@ describe('Article Operations', () => {
     cy.contains('.chat-panel', 'Persisted answer').should('be.visible');
 
     cy.get('[data-testid="chat-new-session"]').click();
-    cy.wait('@createChatSession');
-    cy.wait('@chatMessages');
+    cy.get('@createChatSession.all').should('have.length', 1);
     cy.contains('.chat-panel', 'Persisted answer').should('not.exist');
     cy.get('[data-testid="chat-session-switcher"]').click();
     cy.get('.chat-panel [data-session-id="1"]').click();
@@ -465,6 +465,8 @@ describe('Article Operations', () => {
     cy.wait('@aiChat');
     cy.wait('@chatMessages');
     cy.contains('.chat-panel', 'trigger failure').should('be.visible');
-    cy.contains('Failed to get response from AI. Please try again.').should('be.visible');
+    cy.contains('The AI service is temporarily unavailable. Please try again later.').should(
+      'be.visible'
+    );
   });
 });

--- a/frontend/cypress/e2e/reading-interactions.cy.ts
+++ b/frontend/cypress/e2e/reading-interactions.cy.ts
@@ -76,6 +76,43 @@ function openArticle() {
 }
 
 describe('Reading interactions', () => {
+  it('keeps new chats local until sending and creates only one session for the first question', () => {
+    let creates = 0;
+    let sends = 0;
+    setup({ ai_chat_enabled: 'true', translation_enabled: 'false' });
+    cy.intercept('GET', '/api/ai/profiles', []);
+    cy.intercept('GET', '/api/ai/chat/sessions*', []);
+    cy.intercept('POST', '/api/ai/chat/session/create', (req) => {
+      creates++;
+      expect(req.body.article_id).to.equal(1);
+      expect(req.body.title).to.equal('First real question');
+      req.reply({ id: 10, article_id: 1, title: req.body.title, message_count: 0 });
+    }).as('createChat');
+    cy.intercept('POST', '/api/ai-chat', (req) => {
+      sends++;
+      expect(creates).to.equal(1);
+      expect(req.body.session_id).to.equal(10);
+      expect(req.body.messages.at(-1).content).to.equal('First real question');
+      req.reply({ response: 'First answer', session_id: 10 });
+    }).as('sendChat');
+    openArticle();
+    cy.get('button[title="AI Chat"]').click();
+    cy.get('[data-testid="chat-new-session"]').click().click();
+    cy.get('input[placeholder="Type a message..."]').type('Discard this draft');
+    cy.get('[data-testid="chat-new-session"]').click();
+    cy.get('input[placeholder="Type a message..."]').should('have.value', '');
+    cy.then(() => expect(creates).to.equal(0));
+    cy.get('input[placeholder="Type a message..."]').type('First real question{enter}');
+    cy.wait('@createChat');
+    cy.wait('@sendChat');
+    cy.contains('.chat-panel', 'First answer').should('be.visible');
+    cy.get('[data-testid="chat-new-session"]').click().click();
+    cy.then(() => {
+      expect(creates).to.equal(1);
+      expect(sends).to.equal(1);
+    });
+  });
+
   it('translates only the requested title or paragraph in manual mode, and retries failures', () => {
     let calls = 0;
     let paragraphCalls = 0;

--- a/frontend/src/components/article/ArticleChatPanel.vue
+++ b/frontend/src/components/article/ArticleChatPanel.vue
@@ -151,29 +151,14 @@ async function selectSession(sessionId: number, force = false) {
   }
 }
 
-async function createNewSession() {
+function createNewSession() {
   if (isLoading.value) return;
-  try {
-    const response = await fetch('/api/ai/chat/session/create', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        article_id: props.article.id,
-        title: t('article.chat.newChat'),
-      }),
-    });
-
-    if (response.ok) {
-      const newSession = await response.json();
-      sessions.value.unshift(newSession);
-      // Select the new session and reset for first message
-      await selectSession(newSession.id);
-      // Ensure isFirstMessage is true for new sessions
-      isFirstMessage.value = true;
-    }
-  } catch (e) {
-    console.error('Failed to create session:', e);
-  }
+  currentSessionId.value = null;
+  messages.value = [];
+  inputMessage.value = '';
+  isFirstMessage.value = true;
+  showSessions.value = false;
+  cancelEditSession();
 }
 
 async function deleteSession(sessionId: number, e: Event) {
@@ -281,19 +266,37 @@ async function sendMessage() {
   const message = inputMessage.value.trim();
   if (!message || isLoading.value) return;
 
-  messages.value.push({
-    id: 0,
-    role: 'user',
-    content: message,
-    created_at: new Date().toISOString(),
-  });
-  inputMessage.value = '';
   isLoading.value = true;
 
-  await nextTick();
-  scrollToBottom();
-
   try {
+    if (!currentSessionId.value) {
+      const response = await fetch('/api/ai/chat/session/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          article_id: props.article.id,
+          title: Array.from(message).slice(0, 60).join(''),
+        }),
+      });
+      if (!response.ok) throw new Error((await readAIError(response)).message);
+      const session: ChatSession = await response.json();
+      if (!Number.isInteger(session.id) || session.id <= 0) {
+        throw new Error('Invalid chat session ID');
+      }
+      currentSessionId.value = session.id;
+      sessions.value.unshift(session);
+    }
+
+    messages.value.push({
+      id: 0,
+      role: 'user',
+      content: message,
+      created_at: new Date().toISOString(),
+    });
+    inputMessage.value = '';
+    await nextTick();
+    scrollToBottom();
+
     // Prepare article content for AI context
     // Use up to 50000 characters for better context while staying reasonable
     const articleContent = props.articleContent ? props.articleContent.slice(0, 50000) : '';


### PR DESCRIPTION
“新建对话”现在只清空本地草稿，重复点击不会创建空白历史记录；已有输入也会被清空。首次实际发送先通过短请求取得会话 ID，再发送 AI 请求，会话使用首问前 60 个 Unicode 字符命名，创建期间禁止重复发送。

Closes #1109

验证：ESLint、14 文件 119 项单元测试、前端构建、macOS Wails 构建、git diff --check 通过。Electron/Cypress reading-interactions 7 项通过，覆盖重复新建、清空草稿、首次先创建再发送；既有聊天历史及请求失败恢复用例定向通过。聊天 fixture 补齐模型列表，并按现有 HTTP 500 错误分类调整提示断言。

article-operations 全文件额外运行中，非聊天的旧侧栏未读/收藏文本定位及 AI 搜索下一篇定位共 3 项未通过，未在此 PR 修改无关行为。聊天用例已单独复验通过。
