### PR TITLE
fix：修复规则逻辑按钮中英文显示

### DIFF
--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -5,6 +5,8 @@ import { mount } from '@vue/test-utils';
 import { createPinia } from 'pinia';
 import { createI18n } from 'vue-i18n';
 import en from './i18n/locales/en';
+import zh from './i18n/locales/zh';
+import RuleLogicConnector from './components/modals/rules/RuleLogicConnector.vue';
 import App from './App.vue';
 import { setSettingsFromRawData } from './composables/core/useSettings';
 import { getRecommendedFonts } from './utils/fontDetector';
@@ -244,5 +246,26 @@ describe('App', () => {
     );
 
     getContextSpy.mockRestore();
+  });
+});
+
+
+describe('Rule logic localization', () => {
+  it('localizes AND/OR labels while preserving emitted rule operators', async () => {
+    const i18n = createI18n({ legacy: false, locale: 'zh', messages: { en, zh } });
+    const wrapper = mount(RuleLogicConnector, {
+      props: { logic: 'and' },
+      global: { plugins: [i18n] },
+    });
+    const buttons = wrapper.findAll('button');
+    expect(buttons.map((button) => button.text())).toEqual(['且', '或']);
+    await buttons[1].trigger('click');
+    await buttons[0].trigger('click');
+    expect(wrapper.emitted('update')).toEqual([['or'], ['and']]);
+
+    i18n.global.locale.value = 'en';
+    await nextTick();
+    expect(buttons.map((button) => button.text())).toEqual(['AND', 'OR']);
+    wrapper.unmount();
   });
 });

--- a/frontend/src/components/modals/rules/RuleLogicConnector.vue
+++ b/frontend/src/components/modals/rules/RuleLogicConnector.vue
@@ -14,8 +14,8 @@ const emit = defineEmits<{
 const { t } = useI18n();
 
 const logicOptions: Array<{ value: 'and' | 'or'; labelKey: string }> = [
-  { value: 'and', labelKey: 'and' },
-  { value: 'or', labelKey: 'or' },
+  { value: 'and', labelKey: 'modal.filter.and' },
+  { value: 'or', labelKey: 'modal.filter.or' },
 ];
 </script>
 


### PR DESCRIPTION
规则编辑器的逻辑连接按钮使用了不存在的顶层翻译键，中文界面仍显示 and/or。改用已有的规则筛选翻译，中文显示“且 / 或”，英文保持 AND / OR，保存的逻辑值仍为 and / or。

验证：中英文切换及事件值回归、ESLint、前端构建、wails3 build。

Closes #1110
