### PR TITLE
docs：补充AI模型支持聊天的说明

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -643,7 +643,7 @@ const en: TranslationMessages = {
       aiEndpointPlaceholder: 'https://api.openai.com/v1/chat/completions',
       aiFeatures: 'AI Features',
       aiModel: 'Model Name',
-      aiModelDesc: 'AI model to use for translation and summarization',
+      aiModelDesc: 'AI model to use for chat, translation, and summarization',
       aiModelPlaceholder: 'gpt-4o-mini',
       // AI Profile Management
       aiProfiles: 'AI Profiles',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -627,7 +627,7 @@ const zh: TranslationMessages = {
       aiEndpointPlaceholder: 'https://api.openai.com/v1/chat/completions',
       aiFeatures: 'AI 功能',
       aiModel: '模型名称',
-      aiModelDesc: '用于翻译和摘要的 AI 模型',
+      aiModelDesc: '用于聊天、翻译和摘要的 AI 模型',
       aiModelPlaceholder: 'gpt-4o-mini',
       // AI 配置管理
       aiProfiles: 'AI 配置',


### PR DESCRIPTION
AI 模型说明遗漏了聊天功能。补齐中英文模型说明，使配置用途覆盖聊天、翻译和摘要。

验证：ESLint、现有前端单元测试、前端构建、wails3 build。

Closes #1111
