### PR TITLE
fix：移除 v1.3.32 版本文件的 UTF-8 BOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿<h1><img src="imgs/logo-rounded.png" alt="MrRSS logo" style="height: 40px;"/>&nbsp;MrRSS</h1>
+<h1><img src="imgs/logo-rounded.png" alt="MrRSS logo" style="height: 40px;"/>&nbsp;MrRSS</h1>
 
 <a href="https://trendshift.io/repositories/15731" target="_blank"><img src="https://trendshift.io/api/badge/repositories/15731" alt="DevXDojo%2FMrRSS | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,4 +1,4 @@
-﻿<h1><img src="imgs/logo-rounded.png" alt="MrRSS logo" style="height: 40px;"/>&nbsp;MrRSS</h1>
+<h1><img src="imgs/logo-rounded.png" alt="MrRSS logo" style="height: 40px;"/>&nbsp;MrRSS</h1>
 
 <a href="https://trendshift.io/repositories/15731" target="_blank"><img src="https://trendshift.io/api/badge/repositories/15731" alt="DevXDojo%2FMrRSS | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 

--- a/build/config.yml
+++ b/build/config.yml
@@ -1,4 +1,4 @@
-﻿# This file contains the configuration for this project.
+# This file contains the configuration for this project.
 # When you update `info` or `fileAssociations`, run `wails3 task common:update:build-assets` to update the assets.
 # Note that this will overwrite any changes you have made to the assets.
 version: '3'

--- a/build/linux/Taskfile.yml
+++ b/build/linux/Taskfile.yml
@@ -1,4 +1,4 @@
-﻿version: '3'
+version: '3'
 
 includes:
   common: ../Taskfile.yml

--- a/build/linux/nfpm/nfpm.yaml
+++ b/build/linux/nfpm/nfpm.yaml
@@ -1,4 +1,4 @@
-﻿# Feel free to remove those if you don't want/need to use them.
+# Feel free to remove those if you don't want/need to use them.
 # Make sure to check the documentation at https://nfpm.goreleaser.com
 #
 # The lines below are called `modelines`. See `:help modeline`

--- a/docs/SERVER_MODE/swagger.json
+++ b/docs/SERVER_MODE/swagger.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "swagger": "2.0",
     "info": {
         "description": "MrRSS is a modern, cross-platform desktop RSS reader with auto-translation, smart feed discovery, and AI-powered summarization.",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "mrrss-frontend",
   "version": "1.3.32",
   "lockfileVersion": 3,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "mrrss-frontend",
   "private": true,
   "version": "1.3.32",

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
-﻿package version
+package version
 
 // Version is the current application version
 const Version = "1.3.32"

--- a/main-core.go
+++ b/main-core.go
@@ -1,4 +1,4 @@
-﻿//go:build server
+//go:build server
 
 package main
 

--- a/skills/mrrss-assistant/references/api.md
+++ b/skills/mrrss-assistant/references/api.md
@@ -1,4 +1,4 @@
-﻿# MrRSS API Reference
+# MrRSS API Reference
 
 Generated from `docs/SERVER_MODE/swagger.json`. Regenerate with:
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "mrrss-website",
   "version": "1.3.32",
   "lockfileVersion": 3,

--- a/website/package.json
+++ b/website/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "mrrss-website",
   "version": "1.3.32",
   "description": "MrRSS - AI-Powered RSS Reader Landing Page",


### PR DESCRIPTION
官方版本提交 `c558f7435a7c4fea3763d3a84813bb699972975e` 在 13 个版本文件开头加入了 UTF-8 BOM，导致使用 UTF-8 直接读取 Swagger JSON 的技能引用生成器无法解析。本补丁仅移除这 13 个文件各自开头的 `EF BB BF`，保留全部 `1.3.32` 版本值、换行、文件权限及其余字节。

逐文件与基线原始字节比对确认：每个结果都严格等于原文件去掉最前 3 字节，共减少 39 字节。没有功能、依赖、品牌或发行配置变更。

验证通过：

- `git diff --check` 与 13 文件逐字节审计。
- 前端 ESLint（不使用 `--fix`）、14 个文件 / 119 个单元测试、Vite 构建。
- `go vet ./...`、`go test -timeout=5m ./...`。
- Wails `v3.0.0-beta.15` 原生构建；构建生成的图标和 `go mod tidy` 分类调整已恢复，不包含于提交。
- 使用 Python 3.14 重新生成技能 API 引用，与提交中的引用逐字节一致。

本地 Node 26 单元测试使用 `NODE_OPTIONS=--no-experimental-webstorage` 避免原生 Web Storage 与测试环境冲突；没有修改测试配置。

同一提交 `cdb5fd7aa1568fc9216d99f84b7efbb516d3944f` 的复刻仓库 [Test 工作流](https://github.com/marcomarcogd/MRSS/actions/runs/34175872670) 四个作业全部通过：Test Backend、Test Frontend、Validate Skills、Build Check。

该 PR 保持 Draft，目标仅为 `release/v1.3.32`。
