### PR TITLE
fix：同步 v1.3.32 打包版本信息

### DIFF
--- a/build/darwin/Info.dev.plist
+++ b/build/darwin/Info.dev.plist
@@ -10,11 +10,11 @@
         <key>CFBundleIdentifier</key>
             <string>com.mrrss.app</string>
         <key>CFBundleVersion</key>
-            <string>1.3.24</string>
+            <string>1.3.32</string>
         <key>CFBundleGetInfoString</key>
             <string>Built with Wails</string>
         <key>CFBundleShortVersionString</key>
-            <string>1.3.24</string>
+            <string>1.3.32</string>
         <key>CFBundleIconFile</key>
             <string>icons</string>
         <key>LSMinimumSystemVersion</key>

--- a/build/darwin/Info.plist
+++ b/build/darwin/Info.plist
@@ -10,11 +10,11 @@
         <key>CFBundleIdentifier</key>
             <string>com.mrrss.app</string>
         <key>CFBundleVersion</key>
-            <string>1.3.24</string>
+            <string>1.3.32</string>
         <key>CFBundleGetInfoString</key>
             <string>Built with Wails</string>
         <key>CFBundleShortVersionString</key>
-            <string>1.3.24</string>
+            <string>1.3.32</string>
         <key>CFBundleIconFile</key>
             <string>icons</string>
         <key>LSMinimumSystemVersion</key>

--- a/build/darwin/Taskfile.yml
+++ b/build/darwin/Taskfile.yml
@@ -72,9 +72,9 @@ tasks:
           <key>CFBundlePackageType</key>
           <string>APPL</string>
           <key>CFBundleShortVersionString</key>
-          <string>1.3.24</string>
+          <string>1.3.32</string>
           <key>CFBundleVersion</key>
-          <string>1.3.24</string>
+          <string>1.3.32</string>
           <key>LSMinimumSystemVersion</key>
           <string>10.13</string>
           <key>NSHighResolutionCapable</key>

--- a/build/darwin/create-dmg.sh
+++ b/build/darwin/create-dmg.sh
@@ -12,7 +12,7 @@ set -e
 
 APP_NAME="MrRSS"
 # Get version from frontend/package.json if available, otherwise use default
-VERSION=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' frontend/package.json 2>/dev/null | head -1 | sed 's/.*"\([^"]*\)".*/\1/' || echo "1.3.24")
+VERSION=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' frontend/package.json 2>/dev/null | head -1 | sed 's/.*"\([^"]*\)".*/\1/' || echo "1.3.32")
 APP_PUBLISHER="Ch3nyang"
 APP_URL="https://github.com/DevXDojo/MrRSS"
 APP_DESCRIPTION="A Modern, Cross-Platform Desktop RSS Reader"

--- a/build/ios/Info.dev.plist
+++ b/build/ios/Info.dev.plist
@@ -13,9 +13,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.3.24-dev</string>
+    <string>1.3.32-dev</string>
     <key>CFBundleVersion</key>
-    <string>1.3.24</string>
+    <string>1.3.32</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>MinimumOSVersion</key>

--- a/build/ios/Info.plist
+++ b/build/ios/Info.plist
@@ -13,9 +13,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.3.24</string>
+    <string>1.3.32</string>
     <key>CFBundleVersion</key>
-    <string>1.3.24</string>
+    <string>1.3.32</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>MinimumOSVersion</key>

--- a/build/ios/build.sh
+++ b/build/ios/build.sh
@@ -4,8 +4,8 @@ set -e
 # Build configuration
 APP_NAME="MrRSS"
 BUNDLE_ID="com.mrrss.app"
-VERSION="1.3.24"
-BUILD_NUMBER="1.3.24"
+VERSION="1.3.32"
+BUILD_NUMBER="1.3.32"
 BUILD_DIR="build/ios"
 TARGET="simulator"
 

--- a/build/linux/create-appimage.sh
+++ b/build/linux/create-appimage.sh
@@ -13,7 +13,7 @@ set -e
 
 APP_NAME="MrRSS"
 # Get version from frontend/package.json if available, otherwise use default
-VERSION=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' frontend/package.json 2>/dev/null | head -1 | sed 's/.*"\([^"]*\)".*/\1/' || echo "1.3.24")
+VERSION=$(grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' frontend/package.json 2>/dev/null | head -1 | sed 's/.*"\([^"]*\)".*/\1/' || echo "1.3.32")
 # Get architecture from environment variable or default to amd64
 ARCH=${ARCH:-amd64}
 echo "Target architecture: ${ARCH}"

--- a/build/windows/info.json
+++ b/build/windows/info.json
@@ -1,10 +1,10 @@
 {
 	"fixed": {
-		"file_version": "1.3.24"
+		"file_version": "1.3.32"
 	},
 	"info": {
 		"0000": {
-			"ProductVersion": "1.3.24",
+			"ProductVersion": "1.3.32",
 			"CompanyName": "Ch3nyang",
 			"FileDescription": "MrRSS",
 			"LegalCopyright": "Copyright © 2026",

--- a/build/windows/installer.nsi
+++ b/build/windows/installer.nsi
@@ -9,8 +9,8 @@
 ; All paths in this script are relative to the script directory.
 
 !define APP_NAME "MrRSS"
-!define APP_VERSION "1.3.24"
-!define APP_VERSION_NUMERIC "1.3.24.0"  ; NSIS requires X.X.X.X format
+!define APP_VERSION "1.3.32"
+!define APP_VERSION_NUMERIC "1.3.32.0"  ; NSIS requires X.X.X.X format
 !define APP_PUBLISHER "Ch3nyang"
 !define APP_URL "https://github.com/DevXDojo/MrRSS"
 !define APP_DESCRIPTION "A Modern, Cross-Platform Desktop RSS Reader"

--- a/build/windows/nsis/wails_tools.nsh
+++ b/build/windows/nsis/wails_tools.nsh
@@ -14,7 +14,7 @@
     !define INFO_PRODUCTNAME "MrRSS"
 !endif
 !ifndef INFO_PRODUCTVERSION
-    !define INFO_PRODUCTVERSION "1.3.24"
+    !define INFO_PRODUCTVERSION "1.3.32"
 !endif
 !ifndef INFO_COPYRIGHT
     !define INFO_COPYRIGHT "Copyright © 2026"

--- a/build/windows/wails.exe.manifest
+++ b/build/windows/wails.exe.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <assemblyIdentity type="win32" name="com.mrrss.app" version="1.3.24.0" processorArchitecture="*"/>
+    <assemblyIdentity type="win32" name="com.mrrss.app" version="1.3.32.0" processorArchitecture="*"/>
     <dependency>
         <dependentAssembly>
             <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>


### PR DESCRIPTION
发布分支已经更新为 1.3.32，但 macOS、Windows、iOS 的打包元数据仍为 1.3.24，实际生成的 macOS 应用也显示 1.3.24。

本 PR 将 12 个发布与安装元数据文件统一为 1.3.32，包括 macOS/Windows/iOS 元数据及 Linux/macOS 脚本的回退版本。

验证：
- Wails v3.0.0-beta.16 桌面构建通过
- 生成的 MrRSS.app CFBundleShortVersionString 与 CFBundleVersion 均为 1.3.32
- macOS/iOS plist、Windows manifest 和 info.json 语法检查通过
- git diff --check 通过
