### PR TITLE
fix：兼容 Cypress 16 环境配置读取

### DIFF
--- a/frontend/cypress/support/e2e.ts
+++ b/frontend/cypress/support/e2e.ts
@@ -21,31 +21,33 @@ import './commands';
 
 // Global setup before all tests
 before(() => {
-  // Log test environment info
-  cy.log('Testing Environment:', Cypress.env('isCI') ? 'CI' : 'Local')
-  cy.log('Backend URL:', Cypress.env('backendUrl'))
+  cy.env(['isCI', 'backendUrl']).then(({ isCI, backendUrl }) => {
+    // Log test environment info
+    cy.log('Testing Environment:', isCI ? 'CI' : 'Local');
+    cy.log('Backend URL:', backendUrl);
 
-  // Check if backend is available
-  cy.request({
-    url: `${Cypress.env('backendUrl')}/api/feeds`,
-    failOnStatusCode: false,
-  }).then((response) => {
-    if (response.status === 500 || response.status === 0) {
-      cy.log('⚠️ Backend may not be running. Tests might fail.')
-    } else {
-      cy.log('✅ Backend is responding')
-    }
-  })
-})
+    // Check if backend is available
+    cy.request({
+      url: `${backendUrl}/api/feeds`,
+      failOnStatusCode: false,
+    }).then((response) => {
+      if (response.status === 500 || response.status === 0) {
+        cy.log('⚠️ Backend may not be running. Tests might fail.');
+      } else {
+        cy.log('✅ Backend is responding');
+      }
+    });
+  });
+});
 
 // Cleanup after each test
 afterEach(() => {
   // Clear localStorage between tests to prevent state leakage
-  cy.clearCookies()
-  cy.clearLocalStorage()
-})
+  cy.clearCookies();
+  cy.clearLocalStorage();
+});
 
 // Global cleanup after all tests
 after(() => {
-  cy.log('All tests completed')
-})
+  cy.log('All tests completed');
+});


### PR DESCRIPTION
Cypress 16 移除了同步的 Cypress.env()，导致所有 E2E 在全局 before 钩子中止，业务用例无法运行。

本 PR 使用 cy.env() 一次读取 isCI 和 backendUrl，保留原有日志与后端探测逻辑。

验证：
- Cypress 16 reading-interactions：27/27 通过
- Cypress 16 sidebar-management：8/8 通过
- Cypress 16 article-operations：7/10 通过；3 项失败已在升级前基线复现，错误与升级前一致
- 前端构建与 Prettier 检查通过
- git diff --check 通过
