### PR TITLE
fix: sync Miniflux articles and folders

### DIFF
--- a/internal/freshrss/bidirectional_sync.go
+++ b/internal/freshrss/bidirectional_sync.go
@@ -462,7 +462,7 @@ func (s *BidirectionalSyncService) createFeedsFromSubscriptions(ctx context.Cont
 		category := ""
 		if len(sub.Categories) > 0 {
 			for _, cat := range sub.Categories {
-				if strings.HasPrefix(cat.ID, "user/-/label/") {
+				if strings.Contains(cat.ID, "/label/") {
 					originalCategory := cat.Label
 					// Check if this category would conflict with local feeds
 					category = generateFreshRSSCategoryName(originalCategory)
@@ -679,10 +679,10 @@ func (s *BidirectionalSyncService) saveArticlesFromServer(ctx context.Context, a
 		isRead := false
 		isStarred := false
 		for _, cat := range article.Categories {
-			if cat == "user/-/state/com.google/read" {
+			if isGoogleReaderState(cat, "read") {
 				isRead = true
 			}
-			if cat == "user/-/state/com.google/starred" {
+			if isGoogleReaderState(cat, "starred") {
 				isStarred = true
 			}
 		}
@@ -826,6 +826,10 @@ func (s *BidirectionalSyncService) saveArticlesFromServer(ctx context.Context, a
 	}
 
 	return len(mrssArticles), nil
+}
+
+func isGoogleReaderState(category, state string) bool {
+	return strings.HasSuffix(category, "/state/com.google/"+state)
 }
 
 // pushToServer pushes local changes to FreshRSS server

--- a/internal/freshrss/bidirectional_sync_test.go
+++ b/internal/freshrss/bidirectional_sync_test.go
@@ -1,0 +1,17 @@
+package freshrss
+
+import "testing"
+
+func TestIsGoogleReaderStateSupportsFreshRSSAndMinifluxIDs(t *testing.T) {
+	for _, category := range []string{
+		"user/-/state/com.google/read",
+		"user/1/state/com.google/read",
+	} {
+		if !isGoogleReaderState(category, "read") {
+			t.Fatalf("%q was not recognized as read", category)
+		}
+	}
+	if isGoogleReaderState("user/1/state/com.google/starred", "read") {
+		t.Fatal("starred category was recognized as read")
+	}
+}

--- a/internal/freshrss/client.go
+++ b/internal/freshrss/client.go
@@ -20,6 +20,7 @@ type Client struct {
 	baseURL    string
 	username   string
 	password   string
+	provider   Provider
 	authToken  string
 	httpClient *http.Client
 }
@@ -43,6 +44,7 @@ func NewClient(serverURL, username, password string) *Client {
 		baseURL:  serverURL,
 		username: username,
 		password: password,
+		provider: ProviderFreshRSS,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
@@ -64,6 +66,7 @@ func NewClientForProvider(serverURL, username, password, provider string) *Clien
 		baseURL:  strings.TrimSuffix(serverURL, "/"),
 		username: username,
 		password: password,
+		provider: ProviderMiniflux,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
@@ -342,6 +345,9 @@ func (c *Client) GetStreamContents(ctx context.Context, streamID string, exclude
 	if c.authToken == "" {
 		return nil, fmt.Errorf("not authenticated")
 	}
+	if c.provider == ProviderMiniflux {
+		return c.getMinifluxStreamContents(ctx, streamID, excludeTypes, maxItems, continuationToken)
+	}
 
 	// Build URL with parameters
 	params := url.Values{}
@@ -378,34 +384,111 @@ func (c *Client) GetStreamContents(ctx context.Context, streamID string, exclude
 		return nil, fmt.Errorf("stream contents request failed with status %d", resp.StatusCode)
 	}
 
-	var result struct {
-		ID           string `json:"id"`
-		Updated      int64  `json:"updated"`
-		Continuation string `json:"continuation,omitempty"`
-		Items        []struct {
-			ID        string `json:"id"`
-			Title     string `json:"title"`
-			Canonical []struct {
-				Href string `json:"href"`
-			} `json:"canonical"`
-			Summary struct {
-				Content   string `json:"content"`
-				Direction string `json:"direction,omitempty"`
-			} `json:"summary"`
-			Published  int64    `json:"published"`
-			Updated    int64    `json:"updated"` // crawlTimeMsec
-			Author     string   `json:"author,omitempty"`
-			Categories []string `json:"categories"`
-			Origin     struct {
-				StreamID string `json:"streamId"`
-				Title    string `json:"title"`
-				HtmlURL  string `json:"htmlUrl,omitempty"`
-			} `json:"origin,omitempty"`
-		} `json:"items"`
+	return decodeGoogleReaderStreamContents(resp.Body)
+}
+
+// getMinifluxStreamContents fetches entry IDs first because Miniflux exposes
+// Google Reader item content through stream/items/contents rather than the
+// stream/contents endpoint used by FreshRSS.
+func (c *Client) getMinifluxStreamContents(ctx context.Context, streamID string, excludeTypes []string, maxItems int, continuationToken string) (*StreamContentsResult, error) {
+	params := url.Values{}
+	params.Set("output", "json")
+	params.Set("s", streamID)
+	params.Set("n", fmt.Sprintf("%d", maxItems))
+	if continuationToken != "" {
+		params.Set("c", continuationToken)
+	}
+	for _, exclude := range excludeTypes {
+		params.Add("xt", exclude)
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	requestURL := c.baseURL + "/reader/api/0/stream/items/ids?" + params.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create Miniflux item IDs request: %w", err)
+	}
+	req.Header.Set("Authorization", "GoogleLogin auth="+c.authToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Miniflux item IDs request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Miniflux item IDs request failed with status %d", resp.StatusCode)
+	}
+
+	var ids struct {
+		ItemRefs []struct {
+			ID string `json:"id"`
+		} `json:"itemRefs"`
+		Continuation string `json:"continuation,omitempty"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&ids); err != nil {
+		return nil, fmt.Errorf("decode Miniflux item IDs response: %w", err)
+	}
+	if len(ids.ItemRefs) == 0 {
+		return &StreamContentsResult{Continuation: ids.Continuation}, nil
+	}
+
+	token, err := c.GetToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get Miniflux write token: %w", err)
+	}
+	data := url.Values{"T": {token}, "output": {"json"}}
+	for _, item := range ids.ItemRefs {
+		data.Add("i", item.ID)
+	}
+
+	req, err = http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/reader/api/0/stream/items/contents", strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("create Miniflux item contents request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err = c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Miniflux item contents request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Miniflux item contents request failed with status %d", resp.StatusCode)
+	}
+
+	result, err := decodeGoogleReaderStreamContents(resp.Body)
+	if err != nil {
 		return nil, fmt.Errorf("decode stream contents response: %w", err)
+	}
+	result.Continuation = ids.Continuation
+	return result, nil
+}
+
+type googleReaderStreamContents struct {
+	Updated      int64  `json:"updated"`
+	Continuation string `json:"continuation,omitempty"`
+	Items        []struct {
+		ID        string `json:"id"`
+		Title     string `json:"title"`
+		Canonical []struct {
+			Href string `json:"href"`
+		} `json:"canonical"`
+		Summary struct {
+			Content string `json:"content"`
+		} `json:"summary"`
+		Published  int64    `json:"published"`
+		Updated    int64    `json:"updated"`
+		Author     string   `json:"author,omitempty"`
+		Categories []string `json:"categories"`
+		Origin     struct {
+			StreamID string `json:"streamId"`
+		} `json:"origin,omitempty"`
+	} `json:"items"`
+}
+
+func decodeGoogleReaderStreamContents(body io.Reader) (*StreamContentsResult, error) {
+	var result googleReaderStreamContents
+	if err := json.NewDecoder(body).Decode(&result); err != nil {
+		return nil, err
 	}
 
 	articles := make([]Article, 0, len(result.Items))

--- a/internal/freshrss/client_test.go
+++ b/internal/freshrss/client_test.go
@@ -1,6 +1,11 @@
 package freshrss
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
 func TestNewClientForProviderUsesCorrectGoogleReaderRoot(t *testing.T) {
 	tests := []struct {
@@ -39,5 +44,52 @@ func TestGoogleReaderUpdatedTimeSupportsSecondsAndMilliseconds(t *testing.T) {
 	}
 	if got := googleReaderUpdatedTime(1_710_000_300_000).Unix(); got != 1_710_000_300 {
 		t.Fatalf("milliseconds timestamp = %d", got)
+	}
+}
+
+func TestMinifluxGetStreamContentsUsesItemIDsThenContents(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/reader/api/0/stream/items/ids":
+			if r.Method != http.MethodGet || r.URL.Query().Get("s") != "feed/42" {
+				t.Fatalf("unexpected item IDs request: %s %s", r.Method, r.URL)
+			}
+			if got := r.Header.Get("Authorization"); got != "GoogleLogin auth=auth-token" {
+				t.Fatalf("authorization = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"itemRefs":[{"id":"123"}],"continuation":"next-page"}`))
+		case "/reader/api/0/token":
+			_, _ = w.Write([]byte("auth-token"))
+		case "/reader/api/0/stream/items/contents":
+			if r.Method != http.MethodPost {
+				t.Fatalf("contents method = %s", r.Method)
+			}
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			if r.Form.Get("T") != "auth-token" || r.Form.Get("output") != "json" || r.Form.Get("i") != "123" {
+				t.Fatalf("unexpected contents form: %v", r.Form)
+			}
+			_, _ = w.Write([]byte(`{"updated":1710000000,"items":[{"id":"123","title":"Entry","canonical":[{"href":"https://example.com/article"}],"summary":{"content":"body"},"published":1710000000,"updated":1710000001,"categories":["user/1/state/com.google/read"],"origin":{"streamId":"feed/42"}}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClientForProvider(server.URL, "user", "password", string(ProviderMiniflux))
+	client.authToken = "auth-token"
+	result, err := client.GetStreamContents(context.Background(), "feed/42", nil, 100, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Items) != 1 || result.Items[0].URL != "https://example.com/article" {
+		t.Fatalf("unexpected items: %#v", result.Items)
+	}
+	if result.Items[0].Updated.Unix() != 1710000001 {
+		t.Fatalf("updated = %d", result.Items[0].Updated.Unix())
+	}
+	if result.Continuation != "next-page" {
+		t.Fatalf("continuation = %q", result.Continuation)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the Miniflux Google Reader compatibility integration after the initial provider support merged.

- Fetches Miniflux article IDs from `stream/items/ids`, then fetches their content through `stream/items/contents`, which is the API Miniflux implements.
- Preserves the existing FreshRSS `stream/contents` behavior.
- Supports Miniflux category and state IDs in the `user/<id>/...` form, so synced feeds retain folders and read/starred state imports correctly.
- Adds HTTP-level client coverage for the Miniflux two-step article fetch and unit coverage for provider-neutral state matching.

## Verification

- `go test -timeout=5m ./internal/freshrss ./internal/handlers/article ./internal/database ./internal/rules`